### PR TITLE
V1 custom code

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,2 +1,10 @@
 # Specify files that shouldn't be modified by Fern
 README.md
+
+src/SchematicHQ.Client.Test/TestCache.cs
+src/SchematicHQ.Client.Test/TestEventBuffer.cs
+src/SchematicHQ.Client/Cache.cs
+src/SchematicHQ.Client/Core/ClientOptionsCustom.cs
+src/SchematicHQ.Client/EventBuffer.cs
+src/SchematicHQ.Client/Logger.cs
+src/SchematicHQ.Client/Schematic.cs

--- a/.fernignore
+++ b/.fernignore
@@ -3,6 +3,8 @@ README.md
 
 src/SchematicHQ.Client.Test/TestCache.cs
 src/SchematicHQ.Client.Test/TestEventBuffer.cs
+src/SchematicHQ.Client.Test/TestClient.cs
+src/SchematicHQ.Client.Test/TestLogger.cs
 src/SchematicHQ.Client/Cache.cs
 src/SchematicHQ.Client/Core/ClientOptionsCustom.cs
 src/SchematicHQ.Client/EventBuffer.cs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,22 @@ jobs:
       - name: Build Release
         run: dotnet build src -c Release /p:ContinuousIntegrationBuild=true
 
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - uses: actions/checkout@master
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 8.x
+
+      - name: Build Release
+        run: dotnet test src
 
   publish:
     needs: [compile]

--- a/README.md
+++ b/README.md
@@ -1,26 +1,24 @@
 # Schematic .NET Library
 
-[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-SDK%20generated%20by%20Fern-brightgreen)](https://github.com/fern-api/fern)
-
 The official Schematic C# library, supporting .NET Standard, .NET Core, and .NET Framework.
 
-## Installation
+## Installation and Setup
 
-Using the .NET Core command-line interface (CLI) tools:
+1. Install the library using the .NET Core command-line interface (CLI) tools:
 
 ```sh
 dotnet add package SchematicHQ.Client
 ```
 
-Using the NuGet Command Line Interface (CLI):
+or using the NuGet Command Line Interface (CLI):
 
 ```sh
 nuget install SchematicHQ.Client
 ```
 
-## Instantiation
-Instantiate the SDK using the `Schematic` client class. Note that all
-of the SDK methods are awaitable!
+2. [Issue an API key](https://docs.schematichq.com/quickstart#create-an-api-key) for the appropriate environment using the [Schematic app](https://app.schematichq.com/settings/api-keys).
+
+3. Using this secret key, initialize a client in your application:
 
 ```csharp
 using SchematicHQ;
@@ -28,14 +26,272 @@ using SchematicHQ;
 Schematic schematic = new Schematic("YOUR_API_KEY")
 ```
 
-## HTTP Client
-You can override the HttpClient by passing in `ClientOptions`.
+## Usage
+
+### Sending identify events
+
+Create or update users and companies using identify events.
+
+```csharp
+using SchematicHQ.Client;
+using System.Collections.Generic;
+using OneOf;
+
+Schematic schematic = new Schematic("YOUR_API_KEY");
+
+schematic.Identify(
+    keys: new Dictionary<string, string>
+    {
+        { "email", "wcoyote@acme.net" },
+        { "user_id", "your-user-id" }
+    },
+    company: new EventBodyIdentifyCompany
+    {
+        Keys = new Dictionary<string, string> { { "id", "your-company-id" } },
+        Name = "Acme Widgets, Inc.",
+        Traits = new Dictionary<string, OneOf<string, double, bool, OneOf<string, double, bool>>>
+        {
+            { "city", "Atlanta" }
+        }
+    },
+    name: "Wile E. Coyote",
+    traits: new Dictionary<string, OneOf<string, double, bool, OneOf<string, double, bool>>>
+    {
+        { "login_count", 24 },
+        { "is_staff", false }
+    }
+);
+```
+
+This call is non-blocking and there is no response to check.
+
+### Sending track events
+
+Track activity in your application using track events; these events can later be used to produce metrics for targeting.
+
+```csharp
+Schematic schematic = new Schematic("YOUR_API_KEY");
+schematic.Track(
+    eventName: "some-action",
+    user: new Dictionary<string, string> { { "user_id", "your-user-id" } },
+    company: new Dictionary<string, string> { { "id", "your-company-id" } }
+);
+```
+
+This call is non-blocking and there is no response to check.
+
+### Creating and updating companies
+
+Although it is faster to create companies and users via identify events, if you need to handle a response, you can use the companies API to upsert companies. Because you use your own identifiers to identify companies, rather than a Schematic company ID, creating and updating companies are both done via the same upsert operation:
+
+
+```csharp
+using SchematicHQ.Client;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+Schematic schematic = new Schematic("YOUR_API_KEY");
+
+// Creating and updating companies
+async Task UpsertCompanyExample()
+{
+    var response = await schematic.API.Companies.UpsertCompanyAsync(new UpsertCompanyRequestBody
+    {
+        Keys = new Dictionary<string, string> { { "id", "your-company-id" } },
+        Name = "Acme Widgets, Inc.",
+        Traits = new Dictionary<string, object>
+        {
+            { "city", "Atlanta" },
+            { "high_score", 25 },
+            { "is_active", true }
+        }
+    });
+
+    // Handle the response as needed
+    Console.WriteLine($"Company upserted: {response.Data.Name}");
+}
+```
+
+You can define any number of company keys; these are used to address the company in the future, for example by updating the company's traits or checking a flag for the company.
+
+You can also define any number of company traits; these can then be used as targeting parameters.
+
+### Creating and updating users
+
+Similarly, you can upsert users using the Schematic API, as an alternative to using identify events. Because you use your own identifiers to identify users, rather than a Schematic user ID, creating and updating users are both done via the same upsert operation:
+
+```csharp
+using SchematicHQ.Client;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+Schematic schematic = new Schematic("YOUR_API_KEY");
+
+// Creating and updating users
+async Task UpsertUserExample()
+{
+    var response = await schematic.API.Companies.UpsertUserAsync(new UpsertUserRequestBody
+    {
+        Keys = new Dictionary<string, string>
+        {
+            { "email", "wcoyote@acme.net" },
+            { "user_id", "your-user-id" }
+        },
+        Name = "Wile E. Coyote",
+        Traits = new Dictionary<string, object>
+        {
+            { "city", "Atlanta" },
+            { "high_score", 25 },
+            { "is_active", true }
+        },
+        Company = new Dictionary<string, string> { { "id", "your-company-id" } }
+    });
+
+    // Handle the response as needed
+    Console.WriteLine($"User upserted: {response.Data.Name}");
+}
+```
+
+You can define any number of user keys; these are used to address the user in the future, for example by updating the user's traits or checking a flag for the user.
+
+You can also define any number of user traits; these can then be used as targeting parameters.
+
+### Checking flags
+
+When checking a flag, you'll provide keys for a company and/or keys for a user. You can also provide no keys at all, in which case you'll get the default value for the flag.
+
+```csharp
+Schematic schematic = new Schematic("YOUR_API_KEY");
+
+bool flagValue = await schematic.CheckFlag(
+    "some-flag-key",
+    company: new Dictionary<string, string> { { "id", "your-company-id" } },
+    user: new Dictionary<string, string> { { "user_id", "your-user-id" } }
+);
+```
+
+## Configuration Options
+
+There are a number of configuration options that can be specified passing in `ClientOptions` as a second parameter when instantiating the Schematic client.
+
+### Flag Check Options
+
+By default, the client will do some local caching for flag checks. If you would like to change this behavior, you can do so using an initialization option to specify the max size of the cache (in terms of number of cached items) and the max age of the cache (in milliseconds):
+
+```csharp
+using SchematicHQ.Client;
+using System.Collections.Generic;
+
+int cacheMaxItems = 1000; // Max number of entries in the cache
+int cacheTtl = 1000; // TTL in milliseconds
+
+var options = new ClientOptions
+{
+    CacheProviders = new List<ICacheProvider<bool>>
+    {
+        new LocalCache<bool>(cacheMaxItems, cacheTtl)
+    }
+};
+
+Schematic schematic = new Schematic("YOUR_API_KEY", options);
+```
+
+You can also disable local caching entirely; bear in mind that, in this case, every flag check will result in a network request:
+
+```csharp
+using SchematicHQ.Client;
+using System.Collections.Generic;
+
+var options = new ClientOptions
+{
+    CacheProviders = new List<ICacheProvider<bool>>()
+};
+
+Schematic schematic = new Schematic("YOUR_API_KEY", options);
+```
+
+You may want to specify default flag values for your application, which will be used if there is a service interruption or if the client is running in offline mode (see below):
+
+```csharp
+using SchematicHQ.Client;
+using System.Collections.Generic;
+
+var options = new ClientOptions
+{
+    FlagDefaults = new Dictionary<string, bool>
+    {
+        { "some-flag-key", true }
+    }
+};
+
+Schematic schematic = new Schematic("YOUR_API_KEY", options);
+```
+
+### Offline Mode
+
+In development or testing environments, you may want to avoid making network requests to the Schematic API. You can run Schematic in offline mode by specifying the `Offline` option; in this case, it does not matter what API key you specify:
+
+```csharp
+using SchematicHQ.Client;
+
+var options = new ClientOptions
+{
+    Offline = true
+};
+
+Schematic schematic = new Schematic("", options); // API key doesn't matter in offline mode
+```
+
+Offline mode works well with flag defaults:
+
+```csharp
+using SchematicHQ.Client;
+using System.Collections.Generic;
+
+var options = new ClientOptions
+{
+    FlagDefaults = new Dictionary<string, bool>
+    {
+        { "some-flag-key", true }
+    },
+    Offline = true
+};
+
+Schematic schematic = new Schematic("", options);
+
+bool flagValue = await schematic.CheckFlag("some-flag-key"); // Returns true
+```
+
+
+### HTTP Client
+You can override the HttpClient:
 
 ```csharp
 schematic = new Schematic("YOUR_API_KEY", new ClientOptions{
     HttpClient = ... // Override the Http Client
     BaseURL = ... // Override the Base URL
 })
+```
+
+### Retries
+429 Rate Limit, and >=500 Internal errors will all be
+retried twice with exponential backoff. You can override this behavior
+globally or per-request.
+
+```csharp
+var schematic = new Schematic("...", new ClientOptions{
+    MaxRetries = 1 // Only retry once
+});
+```
+
+### Timeouts
+The SDK defaults to a 60s timeout. You can override this behaviour
+globally or per-request.
+
+```csharp
+var schematic = new Schematic("...", new ClientOptions{
+    TimeoutInSeconds = 20 // Lower timeout
+});
 ```
 
 ## Exception Handling
@@ -51,42 +307,6 @@ try {
   System.Console.WriteLine(e.Message)
   System.Console.WriteLine(e.StatusCode)
 }
-```
-
-## Usage
-
-Below are code snippets of how you can use the C# SDK.
-
-```csharp
-using SchematicHQ;
-
-Schematic schematic = new Schematic("YOUR_API_KEY")
-Employee employee = schematic.Accounts.ListApiKeysAsync(
-    new ListApiKeysRequest{
-        RequireEnvironment = true
-    }
-);
-```
-
-## Retries
-429 Rate Limit, and >=500 Internal errors will all be
-retried twice with exponential backoff. You can override this behavior
-globally or per-request.
-
-```csharp
-var schematic = new Schematic("...", new ClientOptions{
-    MaxRetries = 1 // Only retry once
-});
-```
-
-## Timeouts
-The SDK defaults to a 60s timeout. You can override this behaviour
-globally or per-request.
-
-```csharp
-var schematic = new Schematic("...", new ClientOptions{
-    TimeoutInSeconds = 20 // Lower timeout
-});
 ```
 
 ## Contributing

--- a/src/SchematicHQ.Client.Test/SchematicHQ.Client.Test.csproj
+++ b/src/SchematicHQ.Client.Test/SchematicHQ.Client.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/SchematicHQ.Client.Test/SchematicHQ.Client.Test.csproj
+++ b/src/SchematicHQ.Client.Test/SchematicHQ.Client.Test.csproj
@@ -10,11 +10,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
-        <PackageReference Include="NUnit" Version="3.13.3"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.4.2"/>
-        <PackageReference Include="NUnit.Analyzers" Version="3.6.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+        <PackageReference Include="coverlet.collector" Version="3.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SchematicHQ.Client.Test/TestCache.cs
+++ b/src/SchematicHQ.Client.Test/TestCache.cs
@@ -1,0 +1,61 @@
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace SchematicHQ.Client.Test
+{
+    [TestFixture]
+    public class TestCache
+    {
+        [Test]
+        public void TestCacheGetAndSet()
+        {
+            var cache = new LocalCache<string>(maxItems: 1000, ttl: 5000);
+
+            cache.Set("key1", "value1");
+            Assert.AreEqual("value1", cache.Get("key1"));
+
+            cache.Set("key2", "value2", ttlOverride: 1);
+            Assert.AreEqual("value2", cache.Get("key2"));
+
+            // Wait for the TTL to expire
+            Task.Delay(TimeSpan.FromSeconds(2)).Wait();
+            Assert.IsNull(cache.Get("key2"));
+        }
+
+        [Test]
+        public void TestCacheEviction()
+        {
+            var cache = new LocalCache<string>(maxItems: 2, ttl: 5000);
+
+            cache.Set("key1", "a");
+            cache.Set("key2", "b");
+
+            // Access key1, making it more recently used than key2
+            Assert.AreEqual("a", cache.Get("key1"));
+
+            // Adding a new key should evict the least recently used key,
+            // which will now be key2
+            cache.Set("key3", "c");
+
+            Assert.IsNull(cache.Get("key2"));
+            Assert.AreEqual("a", cache.Get("key1"));
+            Assert.AreEqual("c", cache.Get("key3"));
+        }
+
+        [Test]
+        public void TestCacheExpiration()
+        {
+            var cache = new LocalCache<string>(maxItems: 1000, ttl: 1000);
+
+            cache.Set("key1", "value1");
+            Assert.AreEqual("value1", cache.Get("key1"));
+
+            // Wait for the TTL to expire
+            Task.Delay(TimeSpan.FromSeconds(2)).Wait();
+            Assert.IsNull(cache.Get("key1"));
+        }
+    }
+}

--- a/src/SchematicHQ.Client.Test/TestCache.cs
+++ b/src/SchematicHQ.Client.Test/TestCache.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
-using System;
-using System.Threading.Tasks;
+using System.Data.SqlTypes;
 
 #nullable enable
 
@@ -9,53 +8,167 @@ namespace SchematicHQ.Client.Test
     [TestFixture]
     public class TestCache
     {
-        [Test]
-        public void TestCacheGetAndSet()
+        static IEnumerable<TestCaseData> SeTAndGetTestCases
         {
-            var cache = new LocalCache<string>(maxItems: 1000, ttl: 5000);
+            get
+            {
+                yield return new TestCaseData(new LocalCache<bool>(), true).SetName("TestSetAndGet_Boolean");
+                yield return new TestCaseData(new LocalCache<string>(), "test_string").SetName("TestSetAndGet_string");
+                yield return new TestCaseData(new LocalCache<List<string>>(), new List<string> { "test_string1", "test_string2" }).SetName("TestSetAndGet_RefType");
+            }
+        }
 
-            cache.Set("key1", "value1");
-            Assert.AreEqual("value1", cache.Get("key1"));
+        [Test, TestCaseSource(nameof(SeTAndGetTestCases))]
+        public void Get_ReturnsSetValue<T>(ICacheProvider<T> cache, T value)
+        {
+            string key = "test_key";
 
-            cache.Set("key2", "value2", ttlOverride: 1);
-            Assert.AreEqual("value2", cache.Get("key2"));
+            cache.Set(key: key, val: value);
+            var result = cache.Get(key);
 
-            // Wait for the TTL to expire
-            Task.Delay(TimeSpan.FromSeconds(2)).Wait();
-            Assert.IsNull(cache.Get("key2"));
+            Assert.That(result, Is.EqualTo(value));
         }
 
         [Test]
-        public void TestCacheEviction()
+        public void Test_DefaultTTL()
         {
-            var cache = new LocalCache<string>(maxItems: 2, ttl: 5000);
+            LocalCache<bool?> cacheProvider = new LocalCache<bool?>(maxItems: 1);
+            bool? expectedResult = true;
+            var key = "test_key";
 
-            cache.Set("key1", "a");
-            cache.Set("key2", "b");
+            cacheProvider.Set(key: key, val: expectedResult);
+            var existingResult = cacheProvider.Get(key);
+            Thread.Sleep(LocalCache<bool>.DEFAULT_CACHE_TTL + TimeSpan.FromMilliseconds(5));
+            var evictedResult = cacheProvider.Get(key);
 
-            // Access key1, making it more recently used than key2
-            Assert.AreEqual("a", cache.Get("key1"));
-
-            // Adding a new key should evict the least recently used key,
-            // which will now be key2
-            cache.Set("key3", "c");
-
-            Assert.IsNull(cache.Get("key2"));
-            Assert.AreEqual("a", cache.Get("key1"));
-            Assert.AreEqual("c", cache.Get("key3"));
+            Assert.That(existingResult, Is.EqualTo(expectedResult));
+            Assert.That(evictedResult, Is.Null);
         }
 
         [Test]
-        public void TestCacheExpiration()
+        public void Test_DefaultCapacity()
         {
-            var cache = new LocalCache<string>(maxItems: 1000, ttl: 1000);
+            LocalCache<int?> cacheProvider = new LocalCache<int?>(ttl: TimeSpan.FromMinutes(10));
+            int? expectedResult = -1;
+            var key = "test_key";
 
-            cache.Set("key1", "value1");
-            Assert.AreEqual("value1", cache.Get("key1"));
+            cacheProvider.Set(key: key, val: expectedResult);
+            foreach (int i in Enumerable.Range(1, LocalCache<bool>.DEFAULT_CACHE_CAPACITY - 1))
+            {
+                cacheProvider.Set(key: i.ToString(), val: i);
 
-            // Wait for the TTL to expire
-            Task.Delay(TimeSpan.FromSeconds(2)).Wait();
-            Assert.IsNull(cache.Get("key1"));
+                Assert.That(cacheProvider.Get(key: key), Is.EqualTo(expectedResult));
+            }
+            cacheProvider.Set(key: "new_key", val: -2);
+            var evictedResult = cacheProvider.Get(1.ToString());
+
+            Assert.That(cacheProvider.Get(key: key), Is.EqualTo(expectedResult));
+            Assert.That(cacheProvider.Get(key: "new_key"), Is.EqualTo(-2));
+            Assert.That(evictedResult, Is.Null);
+        }
+
+        [Test]
+        public void Test_NotExistentKeyReturnsDefaultValue()
+        {
+            LocalCache<INullable> cacheProvider = new LocalCache<INullable>(maxItems: 1);
+            Assert.That(cacheProvider.Get("non_existent_key"), Is.Null);
+        }
+
+        [Test]
+        public void Test_ConcurrentAccess()
+        {
+            int numberOfThreads = 10;
+            int cacheCapacity = 30;
+            LocalCache<int?> cacheProvider = new LocalCache<int?>(maxItems: cacheCapacity, ttl: TimeSpan.FromHours(5));
+            var tasks = new List<Task>();
+            var countdownEvent = new CountdownEvent(1);
+
+            for (int t = 0; t < numberOfThreads; t++)
+            {
+                int start = t * cacheCapacity + 1;
+                int end = start + cacheCapacity - 1;
+
+                tasks.Add(Task.Run(() =>
+                {
+                    countdownEvent.Wait();
+                    for (int i = start; i <= end; i++)
+                    {
+                        cacheProvider.Set(i.ToString(), i);
+                    }
+                }));
+            }
+
+            countdownEvent.Signal();
+            Task.WaitAll(tasks.ToArray());
+
+            List<int> cacheHitsIndices = new List<int>();
+
+            for (int i = 1; i <= numberOfThreads * cacheCapacity; i++)
+            {
+                if (cacheProvider.Get(i.ToString()) == i)
+                {
+                    cacheHitsIndices.Add(i);
+                }
+            }
+
+            Assert.That(cacheHitsIndices.Count, Is.EqualTo(cacheCapacity));
+            Assert.That(
+                cacheHitsIndices[cacheCapacity - 1] - cacheHitsIndices[0] + 1,
+                Is.Not.EqualTo(cacheCapacity)
+            );
+        }
+
+        [Test]
+        public void Test_TTLOverride()
+        {
+            LocalCache<int?> cacheProvider = new LocalCache<int?>(maxItems: 1000, ttl: TimeSpan.FromHours(5));
+            var tasks = new List<Task>();
+            var countdownEvent = new CountdownEvent(1);
+            string key = "test_key";
+            int expectedValue = 5;
+            TimeSpan ttlOverride = TimeSpan.FromSeconds(3);
+
+            tasks.Add(Task.Run(() =>
+            {
+                countdownEvent.Wait();
+                cacheProvider.Set(key: key, val: expectedValue, ttlOverride: ttlOverride);
+            }));
+            tasks.Add(Task.Run(() =>
+            {
+                countdownEvent.Wait();
+                Thread.Sleep(1000);
+                Assert.That(cacheProvider.Get(key), Is.EqualTo(expectedValue));
+            }));
+            tasks.Add(Task.Run(() =>
+            {
+                countdownEvent.Wait();
+                Thread.Sleep(ttlOverride + TimeSpan.FromMilliseconds(1));
+                Assert.That(cacheProvider.Get(key), Is.Null);
+            }));
+
+            countdownEvent.Signal();
+            Task.WaitAll(tasks.ToArray());
+        }
+
+        [Test]
+        public void Test_EvictionByLastAccessed()
+        {
+            LocalCache<int?> cacheProvider = new LocalCache<int?>(maxItems: 10, ttl: TimeSpan.FromHours(5));
+            foreach (var i in Enumerable.Range(1, 10))
+            {
+                cacheProvider.Set(i.ToString(), i);
+            }
+
+            foreach (var i in Enumerable.Range(1, 10))
+            {
+                Assert.That(cacheProvider.Get(i.ToString()), Is.EqualTo(i));
+            }
+
+            foreach (var I in Enumerable.Range(1, 10))
+            {
+                cacheProvider.Set((I + 10).ToString(), -1);
+                Assert.That(cacheProvider.Get(I.ToString()), Is.Null);
+            }
         }
     }
 }

--- a/src/SchematicHQ.Client.Test/TestClient.cs
+++ b/src/SchematicHQ.Client.Test/TestClient.cs
@@ -90,7 +90,7 @@ namespace SchematicHQ.Client.Test
             // Arrange
             SetupSchematicTestClient(isOffline: false, response: CreateCheckFlagResponse(HttpStatusCode.OK, false));
             string flagKey = "test_flag";
-            string cacheKey = "test_flag:name=test_company:id=unique_id";
+            string cacheKey = "test_flag:c-name=test_company:u-id=unique_id";
             foreach (var cacheProvider in _options.CacheProviders)
             {
                 cacheProvider.Set(cacheKey, true);

--- a/src/SchematicHQ.Client.Test/TestClient.cs
+++ b/src/SchematicHQ.Client.Test/TestClient.cs
@@ -1,3 +1,5 @@
 namespace SchematicHQ.Client.Test;
 
+#nullable enable
+
 public class TestClient { }

--- a/src/SchematicHQ.Client.Test/TestClient.cs
+++ b/src/SchematicHQ.Client.Test/TestClient.cs
@@ -1,5 +1,250 @@
-namespace SchematicHQ.Client.Test;
+using Moq;
+using NUnit.Framework;
+using System.Net;
+using Moq.Contrib.HttpClient;
+using System.Text.Json;
+using System.Text;
+using OneOf;
 
-#nullable enable
+namespace SchematicHQ.Client.Test
+{
+    [TestFixture]
+    public class SchematicTests
+    {
+        private Schematic _schematic;
+        private ClientOptions _options;
+        private Mock<ISchematicLogger> _logger;
+        private int _defaultEventBufferPeriod = 3; // seconds
 
-public class TestClient { }
+        private HttpResponseMessage CreateCheckFlagResponse(HttpStatusCode code, bool flagValue)
+        {
+            var response = new CheckFlagResponse
+            {
+                Data = new CheckFlagResponseData
+                {
+                    Value = flagValue
+                }
+            };
+            var serializedResponse = JsonSerializer.Serialize(response, new JsonSerializerOptions { WriteIndented = true });
+            return new HttpResponseMessage(code)
+            {
+                Content = new StringContent(serializedResponse, Encoding.UTF8, "application/json")
+            };
+        }
+
+        private void SetupSchematicTestClient(bool isOffline, HttpResponseMessage response, Dictionary<string, bool>? flagDefaults = null)
+        {
+            HttpClient testClient = new OfflineHttpClient();
+            _options = new ClientOptions
+            {
+                Logger = _logger.Object,
+                Offline = isOffline,
+                FlagDefaults = flagDefaults ?? new Dictionary<string, bool>(),
+                DefaultEventBufferPeriod = TimeSpan.FromSeconds(_defaultEventBufferPeriod),
+                CacheProviders = new List<ICacheProvider<bool?>> { new LocalCache<bool?>() }
+            };
+
+            if (!_options.Offline)
+            {
+                var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+                testClient = handler.CreateClient();
+
+                handler.SetupAnyRequest()
+                       .ReturnsAsync(response);
+            }
+            _schematic = new Schematic("dummy_api_key", _options.WithHttpClient(testClient));
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            _logger = new Mock<ISchematicLogger>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_schematic != null) _schematic.Shutdown();
+        }
+
+        [Test]
+        public async Task CheckFlag_CachesResultIfNotCached()
+        {
+            SetupSchematicTestClient(isOffline: false, response: CreateCheckFlagResponse(HttpStatusCode.OK, true));
+            string flagKey = "test_flag";
+
+            // Act
+            var result = await _schematic.CheckFlag(flagKey);
+
+            // Assert
+            Assert.That(result, Is.True);
+            foreach (var cacheProvider in _options.CacheProviders)
+            {
+                Assert.That(cacheProvider.Get(flagKey), Is.EqualTo(true));
+            }
+        }
+
+        [Test]
+        public async Task CheckFlag_StoreCorrectCacheKey()
+        {
+            // Arrange
+            SetupSchematicTestClient(isOffline: false, response: CreateCheckFlagResponse(HttpStatusCode.OK, false));
+            string flagKey = "test_flag";
+            string cacheKey = "test_flag:name=test_company:id=unique_id";
+            foreach (var cacheProvider in _options.CacheProviders)
+            {
+                cacheProvider.Set(cacheKey, true);
+            }
+
+            // Act
+            var result = await _schematic.CheckFlag(
+                flagKey: flagKey,
+                company: new Dictionary<string, string> { { "name", "test_company" } },
+                user: new Dictionary<string, string> { { "id", "unique_id" } }
+            );
+
+            // Assert
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public async Task CheckFlag_ReturnsCachedValueIfExists()
+        {
+            // Arrange
+            SetupSchematicTestClient(isOffline: false, response: CreateCheckFlagResponse(HttpStatusCode.OK, false));
+            string flagKey = "test_flag";
+            foreach (var cacheProvider in _options.CacheProviders)
+            {
+                cacheProvider.Set(flagKey, true);
+            }
+
+            // Act
+            var result = await _schematic.CheckFlag(flagKey);
+
+            // Assert
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public async Task CheckFlag_LogsErrorAndReturnsDefaultOnException()
+        {
+            // Arrange
+            string flagKey = "error_flag";
+            SetupSchematicTestClient(
+                isOffline: false,
+                response: CreateCheckFlagResponse(HttpStatusCode.InternalServerError, false),
+                flagDefaults: new Dictionary<string, bool> { { flagKey, true } }
+            );
+
+            // Act
+            var result = await _schematic.CheckFlag(flagKey);
+
+            // Assert
+            Assert.That(result, Is.True); // default is true for the test flag
+            _logger.Verify(logger => logger.Error("Error checking flag: {0}", It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
+        public async Task Identify_EnqueuesEventNonBlocking()
+        {
+            // Arrange
+            SetupSchematicTestClient(isOffline: false, response: null);
+            var keys = new Dictionary<string, string> { { "user_id", "12345" } };
+            var company = new EventBodyIdentifyCompany { Name = "test_company" };
+
+            // Act
+            var identifyTask = Task.Run(() => _schematic.Identify(keys, company, "John Doe", new Dictionary<string, OneOf<string, double, bool, OneOf<string, double, bool>>>()));
+
+            // Assert
+            await identifyTask; // Ensure the task completes
+            await Task.Delay(100); // Allow some time for the event to be processed asynchronously
+            Assert.That(_schematic.GetBufferWaitingEventCount(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task Track_EnqueuesEventNonBlocking()
+        {
+            // Arrange
+            SetupSchematicTestClient(isOffline: false, response: CreateCheckFlagResponse(HttpStatusCode.OK, false));
+            var company = new Dictionary<string, string> { { "company_id", "67890" } };
+            var user = new Dictionary<string, string> { { "user_id", "12345" } };
+
+            // Act
+            var trackTask = Task.Run(() => _schematic.Track("event_name", company, user, new Dictionary<string, OneOf<string, double, bool, OneOf<string, double, bool>>>()));
+
+            // Assert
+            await trackTask; // Ensure the task completes
+            await Task.Delay(100); // Allow some time for the event to be processed asynchronously
+            Assert.That(_schematic.GetBufferWaitingEventCount(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task EventBuffer_FlushesPeriodically()
+        {
+            // Arrange
+            SetupSchematicTestClient(isOffline: false, response: CreateCheckFlagResponse(HttpStatusCode.OK, false));
+
+            // Act
+            for (int i = 0; i < 10; i++)
+            {
+                _schematic.Track($"event_{i}");
+            }
+
+            // Assert
+            Assert.That(_schematic.GetBufferWaitingEventCount(), Is.EqualTo(10)); // Not Flushed yet
+            await Task.Delay((_defaultEventBufferPeriod * 1000) + 100); // Wait for the periodic flush to occur
+            Assert.That(_schematic.GetBufferWaitingEventCount(), Is.EqualTo(0)); // Assuming the buffer has been flushed
+        }
+
+        [Test]
+        public void Track_OfflineMode()
+        {
+            // Arrange
+            SetupSchematicTestClient(isOffline: true, response: CreateCheckFlagResponse(HttpStatusCode.OK, false));
+
+            // Act
+            for (int i = 0; i < 10; i++)
+            {
+                _schematic.Track($"event_{i}");
+            }
+
+            // Assert
+            Assert.That(_schematic.GetBufferWaitingEventCount(), Is.EqualTo(0)); // nothing should be added to buffer in offline mode
+        }
+
+        [Test]
+        public void Identify_OfflineMode()
+        {
+            // Arrange
+            SetupSchematicTestClient(isOffline: true, response: CreateCheckFlagResponse(HttpStatusCode.OK, false));
+            var keys = new Dictionary<string, string> { { "user_id", "12345" } };
+            var company = new EventBodyIdentifyCompany { Name = "test_company" };
+
+            // Act
+            for (int i = 0; i < 10; i++)
+            {
+                _schematic.Identify(keys, company, "John Doe", new Dictionary<string, OneOf<string, double, bool, OneOf<string, double, bool>>>());
+            }
+
+            // Assert
+            Assert.That(_schematic.GetBufferWaitingEventCount(), Is.EqualTo(0)); // nothing should be added to buffer in offline mode
+        }
+
+        [Test]
+        public async Task CheckFlag_OfflineModeReturnsDefault()
+        {
+            // Arrange
+            SetupSchematicTestClient(
+                isOffline: true,
+                response: CreateCheckFlagResponse(HttpStatusCode.OK, false),
+                flagDefaults: new Dictionary<string, bool> { { "test_flag_key", true } }
+            );
+
+            // Act
+            var result = await _schematic.CheckFlag("test_flag_key");
+
+            // Assert
+            Assert.That(result, Is.True);
+        }
+    }
+}

--- a/src/SchematicHQ.Client.Test/TestEventBuffer.cs
+++ b/src/SchematicHQ.Client.Test/TestEventBuffer.cs
@@ -1,0 +1,239 @@
+using Moq;
+using NUnit.Framework;
+
+namespace SchematicHQ.Client.Tests
+{
+    [TestFixture]
+    public class EventBufferTests
+    {
+        private Mock<ISchematicLogger> _mockLogger;
+        private EventBuffer<int> _buffer;
+        private List<int> _processedItems;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockLogger = new Mock<ISchematicLogger>();
+            _processedItems = new List<int>();
+            _buffer = new EventBuffer<int>(async items =>
+            {
+                lock (_processedItems)
+                {
+                    _processedItems.AddRange(items);
+                }
+                await Task.CompletedTask; // Simulate async operation
+            }, _mockLogger.Object);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _buffer.Dispose();
+        }
+
+        [Test]
+        public void Start_BufferStartsSuccessfully()
+        {
+            _buffer.Start();
+            Assert.DoesNotThrow(() => _buffer.Push(1));
+        }
+
+        [Test]
+        public void Stop_BufferStopsSuccessfully()
+        {
+            _buffer.Start();
+            _buffer.Stop();
+            Assert.Throws<InvalidOperationException>(() => _buffer.Push(1));
+        }
+
+        [Test]
+        public async Task Push_ItemsAreAddedToBuffer()
+        {
+            _buffer.Start();
+            _buffer.Push(1);
+            await _buffer.Flush();
+
+            Assert.That(_processedItems.Count, Is.EqualTo(1));
+            Assert.That(_processedItems[0], Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task Flush_ManualFlushWorks()
+        {
+            _buffer.Start();
+            _buffer.Push(1);
+            await _buffer.Flush();
+
+            Assert.That(_processedItems.Count, Is.EqualTo(1));
+            Assert.That(_processedItems[0], Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Dispose_BufferDisposesSuccessfully()
+        {
+            // Arrange
+            _buffer.Start();
+
+            // Act
+            Assert.DoesNotThrow(() => _buffer.Dispose());
+
+            // Assert
+            var semaphore = GetPrivateFieldValue<SemaphoreSlim>(_buffer, "_semaphore");
+            var cts = GetPrivateFieldValue<CancellationTokenSource>(_buffer, "_cts");
+
+            Assert.That(IsSemaphoreSlimDisposed(semaphore), Is.True, "SemaphoreSlim was not disposed.");
+            Assert.That(IsCancellationTokenSourceDisposed(cts), Is.True, "CancellationTokenSource was not disposed.");
+        }
+
+        [Test]
+        public void PeriodicFlush_FlushesAtInterval()
+        {
+            var autoResetEvent = new AutoResetEvent(false);
+            _buffer = new EventBuffer<int>(async items =>
+            {
+                _processedItems.AddRange(items);
+                autoResetEvent.Set();
+                await Task.CompletedTask; // Simulate async operation
+            }, _mockLogger.Object, 100, TimeSpan.FromMilliseconds(500));
+
+            _buffer.Start();
+            _buffer.Push(1);
+
+            Assert.That(autoResetEvent.WaitOne(2000), Is.True);
+            Assert.That(_processedItems.Count, Is.EqualTo(1));
+            Assert.That(_processedItems[0], Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task Push_ParallelOperations()
+        {
+            _buffer.Start();
+            var tasks = Enumerable.Range(0, 1000).Select(i => Task.Run(() => _buffer.Push(i))).ToArray();
+
+            await Task.WhenAll(tasks);
+            await _buffer.Flush();
+
+            Assert.That(_processedItems.Count, Is.EqualTo(1000));
+        }
+
+        [Test]
+        public async Task Flush_DoesNotInterfereWithPeriodicFlush()
+        {
+            var flushes = 0;
+            var manualFlushes = 0;
+
+            _buffer = new EventBuffer<int>(async items =>
+            {
+                flushes++;
+                if (items.Contains(-1))
+                {
+                    manualFlushes++;
+                }
+                await Task.CompletedTask;
+            }, _mockLogger.Object, 100, TimeSpan.FromMilliseconds(500));
+
+            _buffer.Start();
+
+            var pushTasks = Enumerable.Range(0, 1000).Select(i => Task.Run(() => _buffer.Push(i))).ToArray();
+            await Task.WhenAll(pushTasks);
+
+            // Manual flush
+            _buffer.Push(-1);
+            await _buffer.Flush();
+
+            // Wait for at least one periodic flush
+            Thread.Sleep(2000);
+
+            _buffer.Stop();
+
+            Assert.That(flushes, Is.GreaterThan(1));
+            Assert.That(manualFlushes, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task StartAndStop_ConcurrencyTest()
+        {
+            var startStopTasks = Enumerable.Range(0, 100).Select(async i =>
+            {
+                _buffer.Start();
+                await Task.Delay(10);
+                _buffer.Stop();
+            }).ToArray();
+
+            await Task.WhenAll(startStopTasks);
+
+            // Ensure buffer is stopped at the end
+            Assert.Throws<InvalidOperationException>(() => _buffer.Push(1));
+        }
+
+        [Test]
+        public async Task PushAndFlush_ConcurrencyTest()
+        {
+            _buffer.Start();
+
+            var pushTasks = Enumerable.Range(0, 1000).Select(i => Task.Run(() => _buffer.Push(i))).ToArray();
+            var flushTasks = Enumerable.Range(0, 100).Select(i => Task.Run(async () =>
+            {
+                await Task.Delay(10);
+                await _buffer.Flush();
+            })).ToArray();
+
+            await Task.WhenAll(pushTasks.Concat(flushTasks));
+
+            // Ensure all items were processed
+            await _buffer.Flush();
+            Assert.That(_processedItems.Count, Is.EqualTo(1000));
+        }
+
+        [Test]
+        public async Task SimultaneousFlushes_DoNotInterfere()
+        {
+            _buffer.Start();
+
+            var pushTasks = Enumerable.Range(0, 1000).Select(i => Task.Run(() => _buffer.Push(i))).ToArray();
+
+            await Task.WhenAll(pushTasks);
+
+            var flushTasks = Enumerable.Range(0, 10).Select(i => Task.Run(async () =>
+            {
+                await _buffer.Flush();
+            })).ToArray();
+
+            await Task.WhenAll(flushTasks);
+
+            Assert.That(_processedItems.Count, Is.EqualTo(1000));
+        }
+
+        private bool IsSemaphoreSlimDisposed(SemaphoreSlim semaphore)
+        {
+            try
+            {
+                semaphore.Wait(0); // Attempt a wait operation
+                return false; // If no exception, it's not disposed
+            }
+            catch (ObjectDisposedException)
+            {
+                return true; // If ObjectDisposedException, it's disposed
+            }
+        }
+
+        private bool IsCancellationTokenSourceDisposed(CancellationTokenSource cts)
+        {
+            try
+            {
+                cts.Cancel(); // Attempt to cancel
+                return false; // If no exception, it's not disposed
+            }
+            catch (ObjectDisposedException)
+            {
+                return true; // If ObjectDisposedException, it's disposed
+            }
+        }
+
+        private T GetPrivateFieldValue<T>(object obj, string fieldName)
+        {
+            var field = obj.GetType().GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            return (T)field?.GetValue(obj);
+        }
+    }
+}

--- a/src/SchematicHQ.Client.Test/TestLogger.cs
+++ b/src/SchematicHQ.Client.Test/TestLogger.cs
@@ -1,0 +1,152 @@
+using NUnit.Framework;
+
+namespace SchematicHQ.Client.Tests
+{
+    [TestFixture]
+    public class LoggerTests
+    {
+        private StringWriter _stringWriter;
+        private ConsoleLogger _logger;
+
+        [SetUp]
+        public void SetUp()
+        {
+            //redirect console output
+            _stringWriter = new StringWriter();
+            Console.SetOut(_stringWriter);
+            _logger = new ConsoleLogger();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _stringWriter.Dispose();
+            // reset console output writer 
+            Console.SetOut(Console.Out);
+        }
+
+        [Test]
+        public void Error_ShouldLogErrorMessage()
+        {
+            // Arrange
+            var message = "This is an error message";
+
+            // Act
+            _logger.Error(message);
+
+            // Assert
+            var output = _stringWriter.ToString().Trim();
+            Assert.That(output.Contains("[ERROR]"), Is.True);
+            Assert.That(output.Contains(message), Is.True);
+        }
+
+        [Test]
+        public void Test_Warn_ShouldLogWarnMessage()
+        {
+            // Arrange
+            var message = "This is a warning message";
+
+            // Act
+            _logger.Warn(message);
+
+            // Assert
+            var output = _stringWriter.ToString().Trim();
+            Assert.That(output.Contains("[WARN]"), Is.True);
+            Assert.That(output.Contains(message), Is.True);
+        }
+
+        [Test]
+        public void Test_Info_ShouldLogInfoMessage()
+        {
+            // Arrange
+            var message = "This is an info message";
+
+            // Act
+            _logger.Info(message);
+
+            // Assert
+            var output = _stringWriter.ToString().Trim();
+            Assert.That(output.Contains("[INFO]"), Is.True);
+            Assert.That(output.Contains(message), Is.True);
+        }
+
+        [Test]
+        public void Test_Debug_ShouldLogDebugMessage()
+        {
+            // Arrange
+            var message = "This is a debug message";
+
+            // Act
+            _logger.Debug(message);
+
+            // Assert
+            var output = _stringWriter.ToString().Trim();
+            Assert.That(output.Contains("[DEBUG]"), Is.True);
+            Assert.That(output.Contains(message), Is.True);
+        }
+
+        [Test]
+        public void Test_Error_ShouldFormatMessageWithArgs()
+        {
+            // Arrange
+            var message = "Error {0}";
+            var arg = "123";
+
+            // Act
+            _logger.Error(message, arg);
+
+            // Assert
+            var output = _stringWriter.ToString().Trim();
+            Assert.That(output.Contains("[ERROR]"), Is.True);
+            Assert.That(output.Contains("Error 123"), Is.True);
+        }
+
+        [Test]
+        public void Test_Warn_ShouldFormatMessageWithArgs()
+        {
+            // Arrange
+            var message = "Warning {0}";
+            var arg = "123";
+
+            // Act
+            _logger.Warn(message, arg);
+
+            // Assert
+            var output = _stringWriter.ToString().Trim();
+            Assert.That(output.Contains("[WARN]"), Is.True);
+            Assert.That(output.Contains("Warning 123"), Is.True);
+        }
+
+        [Test]
+        public void Test_Info_ShouldFormatMessageWithArgs()
+        {
+            // Arrange
+            var message = "Info {0}";
+            var arg = "123";
+
+            // Act
+            _logger.Info(message, arg);
+
+            // Assert
+            var output = _stringWriter.ToString().Trim();
+            Assert.That(output.Contains("[INFO]"), Is.True);
+            Assert.That(output.Contains("Info 123"), Is.True);
+        }
+
+        [Test]
+        public void Test_Debug_ShouldFormatMessageWithArgs()
+        {
+            // Arrange
+            var message = "Debug {0}";
+            var arg = "123";
+
+            // Act
+            _logger.Debug(message, arg);
+
+            // Assert
+            var output = _stringWriter.ToString().Trim();
+            Assert.That(output.Contains("[DEBUG]"), Is.True);
+            Assert.That(output.Contains("Debug 123"), Is.True);
+        }
+    }
+}

--- a/src/SchematicHQ.Client/Cache.cs
+++ b/src/SchematicHQ.Client/Cache.cs
@@ -1,114 +1,111 @@
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading;
 
 #nullable enable
 
 namespace SchematicHQ.Client;
 
-public interface ICacheProvider<T>
-{
-    T? Get(string key);
-    void Set(string key, T val, int? ttlOverride = null);
-}
-
-public class LocalCache<T> : ICacheProvider<T>
-{
-    private const int DEFAULT_CACHE_CAPACITY = 1000;
-    private const int DEFAULT_CACHE_TTL = 5000; // 5 seconds
-
-    private readonly ConcurrentDictionary<string, CachedItem<T>> _cache;
-    private readonly LinkedList<string> _lruList;
-    private readonly object _lock = new object();
-    private readonly int _maxItems;
-    private readonly int _ttl;
-
-    public LocalCache(int maxItems = DEFAULT_CACHE_CAPACITY, int ttl = DEFAULT_CACHE_TTL)
+    public interface ICacheProvider<T>
     {
-        _cache = new ConcurrentDictionary<string, CachedItem<T>>();
-        _lruList = new LinkedList<string>();
-        _maxItems = maxItems;
-        _ttl = ttl;
+        T? Get(string key);
+        void Set(string key, T val, TimeSpan? ttlOverride = null);
     }
 
-    public T? Get(string key)
+    public class LocalCache<T> : ICacheProvider<T>
     {
-        if (_maxItems == 0)
-            return default;
+        public const int DEFAULT_CACHE_CAPACITY = 1000;
+        public static readonly TimeSpan DEFAULT_CACHE_TTL = TimeSpan.FromMilliseconds(5000); // 5000 milliseconds
 
-        if (!_cache.TryGetValue(key, out var item))
-            return default;
+        private readonly ConcurrentDictionary<string, CachedItem<T>> _cache;
+        private readonly LinkedList<string> _lruList;
+        private readonly object _lock = new object();
+        private readonly int _maxItems;
+        private readonly TimeSpan _ttl;
 
-        if (DateTime.UtcNow > item.Expiration)
+        public LocalCache(int maxItems = DEFAULT_CACHE_CAPACITY, TimeSpan? ttl = null)
         {
-            Remove(key);
-            return default;
+            _cache = new ConcurrentDictionary<string, CachedItem<T>>();
+            _lruList = new LinkedList<string>();
+            _maxItems = maxItems;
+            _ttl = ttl ?? DEFAULT_CACHE_TTL;
         }
 
-        lock (_lock)
+        public T? Get(string key)
         {
-            _lruList.Remove(item.Node);
-            _lruList.AddFirst(item.Node);
-        }
+            if (_maxItems == 0)
+                return default;
 
-        return item.Value;
-    }
+            if (!_cache.TryGetValue(key, out var item))
+                return default;
 
-    public void Set(string key, T val, int? ttlOverride = null)
-    {
-        if (_maxItems == 0)
-            return;
-
-        var ttl = ttlOverride ?? _ttl;
-        var expiration = DateTime.UtcNow.AddMilliseconds(ttl);
-
-        lock (_lock)
-        {
-            if (_cache.TryGetValue(key, out var existingItem))
+            if (DateTime.UtcNow > item.Expiration)
             {
-                existingItem.Value = val;
-                existingItem.Expiration = expiration;
-                _lruList.Remove(existingItem.Node);
-                _lruList.AddFirst(existingItem.Node);
+                Remove(key);
+                return default;
             }
-            else
-            {
-                if (_cache.Count >= _maxItems)
-                {
-                    var lruKey = _lruList.Last!.Value;
-                    Remove(lruKey);
-                }
 
-                var node = _lruList.AddFirst(key);
-                var newItem = new CachedItem<T>(val, expiration, node);
-                _cache[key] = newItem;
-            }
-        }
-    }
-
-    private void Remove(string key)
-    {
-        if (_cache.TryRemove(key, out var removedItem))
-        {
             lock (_lock)
             {
-                _lruList.Remove(removedItem.Node);
+                _lruList.Remove(item.Node);
+                _lruList.AddFirst(item.Node);
+            }
+
+            return item.Value;
+        }
+
+        public void Set(string key, T val, TimeSpan? ttlOverride = null)
+        {
+            if (_maxItems == 0)
+                return;
+
+            var ttl = ttlOverride ?? _ttl;
+            var expiration = DateTime.UtcNow.Add(ttl);
+
+            lock (_lock)
+            {
+                if (_cache.TryGetValue(key, out var existingItem))
+                {
+                    existingItem.Value = val;
+                    existingItem.Expiration = expiration;
+                    _lruList.Remove(existingItem.Node);
+                    _lruList.AddFirst(existingItem.Node);
+                }
+                else
+                {
+                    if (_cache.Count >= _maxItems)
+                    {
+                        var lruKey = _lruList.Last!.Value;
+                        Remove(lruKey);
+                    }
+
+                    var node = _lruList.AddFirst(key);
+                    var newItem = new CachedItem<T>(val, expiration, node);
+                    _cache[key] = newItem;
+                }
+            }
+        }
+
+        private void Remove(string key)
+        {
+            if (_cache.TryRemove(key, out var removedItem))
+            {
+                lock (_lock)
+                {
+                    _lruList.Remove(removedItem.Node);
+                }
             }
         }
     }
-}
 
-public class CachedItem<T>
-{
-    public T Value { get; set; }
-    public DateTime Expiration { get; set; }
-    public LinkedListNode<string> Node { get; }
-
-    public CachedItem(T value, DateTime expiration, LinkedListNode<string> node)
+    public class CachedItem<T>
     {
-        Value = value;
-        Expiration = expiration;
-        Node = node;
+        public T Value { get; set; }
+        public DateTime Expiration { get; set; }
+        public LinkedListNode<string> Node { get; }
+
+        public CachedItem(T value, DateTime expiration, LinkedListNode<string> node)
+        {
+            Value = value;
+            Expiration = expiration;
+            Node = node;
+        }
     }
-}

--- a/src/SchematicHQ.Client/Cache.cs
+++ b/src/SchematicHQ.Client/Cache.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+
+#nullable enable
+
+namespace SchematicHQ.Client;
+
+public interface ICacheProvider<T>
+{
+    T? Get(string key);
+    void Set(string key, T val, int? ttlOverride = null);
+}
+
+public class LocalCache<T> : ICacheProvider<T>
+{
+    private const int DEFAULT_CACHE_CAPACITY = 1000;
+    private const int DEFAULT_CACHE_TTL = 5000; // 5 seconds
+
+    private readonly ConcurrentDictionary<string, CachedItem<T>> _cache;
+    private readonly LinkedList<string> _lruList;
+    private readonly object _lock = new object();
+    private readonly int _maxItems;
+    private readonly int _ttl;
+
+    public LocalCache(int maxItems = DEFAULT_CACHE_CAPACITY, int ttl = DEFAULT_CACHE_TTL)
+    {
+        _cache = new ConcurrentDictionary<string, CachedItem<T>>();
+        _lruList = new LinkedList<string>();
+        _maxItems = maxItems;
+        _ttl = ttl;
+    }
+
+    public T? Get(string key)
+    {
+        if (_maxItems == 0)
+            return default;
+
+        if (!_cache.TryGetValue(key, out var item))
+            return default;
+
+        if (DateTime.UtcNow > item.Expiration)
+        {
+            Remove(key);
+            return default;
+        }
+
+        lock (_lock)
+        {
+            _lruList.Remove(item.Node);
+            _lruList.AddFirst(item.Node);
+        }
+
+        return item.Value;
+    }
+
+    public void Set(string key, T val, int? ttlOverride = null)
+    {
+        if (_maxItems == 0)
+            return;
+
+        var ttl = ttlOverride ?? _ttl;
+        var expiration = DateTime.UtcNow.AddMilliseconds(ttl);
+
+        lock (_lock)
+        {
+            if (_cache.TryGetValue(key, out var existingItem))
+            {
+                existingItem.Value = val;
+                existingItem.Expiration = expiration;
+                _lruList.Remove(existingItem.Node);
+                _lruList.AddFirst(existingItem.Node);
+            }
+            else
+            {
+                if (_cache.Count >= _maxItems)
+                {
+                    var lruKey = _lruList.Last!.Value;
+                    Remove(lruKey);
+                }
+
+                var node = _lruList.AddFirst(key);
+                var newItem = new CachedItem<T>(val, expiration, node);
+                _cache[key] = newItem;
+            }
+        }
+    }
+
+    private void Remove(string key)
+    {
+        if (_cache.TryRemove(key, out var removedItem))
+        {
+            lock (_lock)
+            {
+                _lruList.Remove(removedItem.Node);
+            }
+        }
+    }
+}
+
+public class CachedItem<T>
+{
+    public T Value { get; set; }
+    public DateTime Expiration { get; set; }
+    public LinkedListNode<string> Node { get; }
+
+    public CachedItem(T value, DateTime expiration, LinkedListNode<string> node)
+    {
+        Value = value;
+        Expiration = expiration;
+        Node = node;
+    }
+}

--- a/src/SchematicHQ.Client/Core/ClientOptionsCustom.cs
+++ b/src/SchematicHQ.Client/Core/ClientOptionsCustom.cs
@@ -8,9 +8,10 @@ public partial class ClientOptions
 {
     public Dictionary<string, bool> FlagDefaults { get; set; }
     public ISchematicLogger Logger { get; set; }
-    public List<ICacheProvider<bool>> CacheProviders { get; set; }
+    public List<ICacheProvider<bool?>> CacheProviders { get; set; }
     public bool Offline { get; set; }
-    public int? EventBufferPeriod { get; set; }
+    public TimeSpan? DefaultEventBufferPeriod { get; set; }
+    public IEventBuffer<CreateEventRequestBody>? EventBuffer { get; set; }
 }
 
 public static class ClientOptionsExtensions
@@ -27,7 +28,8 @@ public static class ClientOptionsExtensions
             Logger = options.Logger,
             CacheProviders = options.CacheProviders,
             Offline = options.Offline,
-            EventBufferPeriod = options.EventBufferPeriod
+            DefaultEventBufferPeriod = options.DefaultEventBufferPeriod,
+            EventBuffer = options.EventBuffer
         };
     }
 }

--- a/src/SchematicHQ.Client/Core/ClientOptionsCustom.cs
+++ b/src/SchematicHQ.Client/Core/ClientOptionsCustom.cs
@@ -1,0 +1,33 @@
+using SchematicHQ.Client.Core;
+
+#nullable enable
+
+namespace SchematicHQ.Client;
+
+public partial class ClientOptions
+{
+    public Dictionary<string, bool> FlagDefaults { get; set; }
+    public ISchematicLogger Logger { get; set; }
+    public List<ICacheProvider<bool>> CacheProviders { get; set; }
+    public bool Offline { get; set; }
+    public int? EventBufferPeriod { get; set; }
+}
+
+public static class ClientOptionsExtensions
+{
+    public static ClientOptions WithHttpClient(this ClientOptions options, HttpClient httpClient)
+    {
+        return new ClientOptions
+        {
+            BaseUrl = options.BaseUrl,
+            HttpClient = httpClient,
+            MaxRetries = options.MaxRetries,
+            TimeoutInSeconds = options.TimeoutInSeconds,
+            FlagDefaults = options.FlagDefaults,
+            Logger = options.Logger,
+            CacheProviders = options.CacheProviders,
+            Offline = options.Offline,
+            EventBufferPeriod = options.EventBufferPeriod
+        };
+    }
+}

--- a/src/SchematicHQ.Client/EventBuffer.cs
+++ b/src/SchematicHQ.Client/EventBuffer.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+#nullable enable
+
+namespace SchematicHQ.Client;
+
+public class EventBuffer : IDisposable
+{
+    private readonly EventsClient _eventsApi;
+    private readonly ISchematicLogger _logger;
+    private readonly int _interval;
+    private readonly int _maxSize;
+    private readonly List<CreateEventRequestBody> _events;
+    private int _currentSize;
+    private readonly object _flushLock = new object();
+    private readonly object _pushLock = new object();
+    private readonly CancellationTokenSource _cancellationTokenSource;
+    private bool _stopped;
+
+    public EventBuffer(EventsClient eventsApi, ISchematicLogger logger, int? period = null)
+    {
+        _eventsApi = eventsApi;
+        _logger = logger;
+        _interval = period ?? DEFAULT_EVENT_BUFFER_PERIOD;
+        _maxSize = DEFAULT_BUFFER_MAX_SIZE;
+        _events = new List<CreateEventRequestBody>();
+        _cancellationTokenSource = new CancellationTokenSource();
+
+        var flushThread = new Thread(PeriodicFlush);
+        flushThread.IsBackground = true;
+        flushThread.Start();
+    }
+
+    private async Task Flush()
+    {
+        List<CreateEventRequestBody> eventsToFlush;
+        lock (_flushLock)
+        {
+            if (_events.Count == 0)
+                return;
+
+            eventsToFlush = _events.FindAll(e => e != null);
+            _events.Clear();
+            _currentSize = 0;
+        }
+
+        try
+        {
+            var request = new CreateEventBatchRequestBody
+            {
+                Events = eventsToFlush
+            };
+            await _eventsApi.CreateEventBatchAsync(request);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error("Error flushing events: {0}", ex.Message);
+        }
+    }
+
+    private void PeriodicFlush()
+    {
+        while (!_cancellationTokenSource.IsCancellationRequested)
+        {
+            Task.Run(async () => await Flush());
+            _cancellationTokenSource.Token.WaitHandle.WaitOne(TimeSpan.FromSeconds(_interval));
+        }
+    }
+
+    public void Push(CreateEventRequestBody @event)
+    {
+        if (_stopped)
+        {
+            _logger.Error("Event buffer is stopped, not accepting new events");
+            return;
+        }
+
+        lock (_pushLock)
+        {
+            if (_currentSize + 1 > _maxSize)
+                Task.Run(async () => await Flush());
+
+            _events.Add(@event);
+            _currentSize += 1;
+        }
+    }
+
+    public void Stop()
+    {
+        try
+        {
+            _stopped = true;
+            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Token.WaitHandle.WaitOne(TimeSpan.FromSeconds(5));
+        }
+        catch (Exception ex)
+        {
+            _logger.Error("Error stopping event buffer: {0}", ex.Message);
+        }
+    }
+
+    public void Dispose()
+    {
+        Stop();
+    }
+
+    private const int DEFAULT_BUFFER_MAX_SIZE = 100; // Flush after 100 events
+    private const int DEFAULT_EVENT_BUFFER_PERIOD = 5; // Flush after 5 seconds
+}

--- a/src/SchematicHQ.Client/Logger.cs
+++ b/src/SchematicHQ.Client/Logger.cs
@@ -1,0 +1,34 @@
+#nullable enable
+
+namespace SchematicHQ.Client;
+
+public interface ISchematicLogger
+{
+    void Error(string message, params object[] args);
+    void Warn(string message, params object[] args);
+    void Info(string message, params object[] args);
+    void Debug(string message, params object[] args);
+}
+
+public class ConsoleLogger : ISchematicLogger
+{
+    public void Error(string message, params object[] args)
+    {
+        Console.WriteLine($"[ERROR] {string.Format(message, args)}");
+    }
+
+    public void Warn(string message, params object[] args)
+    {
+        Console.WriteLine($"[WARN] {string.Format(message, args)}");
+    }
+
+    public void Info(string message, params object[] args)
+    {
+        Console.WriteLine($"[INFO] {string.Format(message, args)}");
+    }
+
+    public void Debug(string message, params object[] args)
+    {
+        Console.WriteLine($"[DEBUG] {string.Format(message, args)}");
+    }
+}

--- a/src/SchematicHQ.Client/Schematic.cs
+++ b/src/SchematicHQ.Client/Schematic.cs
@@ -62,12 +62,12 @@ public partial class Schematic
             string cacheKey = flagKey;
              if (company != null && company.Count > 0)
             {
-                cacheKey += ":" + string.Join(";", company.Select(kvp => $"{kvp.Key}={kvp.Value}"));
+                cacheKey += ":c-" + string.Join(";", company.Select(kvp => $"{kvp.Key}={kvp.Value}"));
             }
 
             if (user != null && user.Count > 0)
             {
-                cacheKey += ":" + string.Join(";", user.Select(kvp => $"{kvp.Key}={kvp.Value}"));
+                cacheKey += ":u-" + string.Join(";", user.Select(kvp => $"{kvp.Key}={kvp.Value}"));
             }
 
             foreach (var provider in _flagCheckCacheProviders)

--- a/src/SchematicHQ.Client/Schematic.cs
+++ b/src/SchematicHQ.Client/Schematic.cs
@@ -1,0 +1,147 @@
+using OneOf;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json.Serialization;
+
+#nullable enable
+
+namespace SchematicHQ.Client;
+
+public partial class Schematic
+{
+    private readonly ClientOptions _options;
+    private readonly EventBuffer _eventBuffer;
+    private readonly ISchematicLogger _logger;
+    private readonly List<ICacheProvider<bool>> _flagCheckCacheProviders;
+    private readonly bool _offline;
+    public readonly SchematicApi API;
+
+    public Schematic(string apiKey, ClientOptions? options = null)
+    {
+        _options = options ?? new ClientOptions();
+        _offline = _options.Offline;
+        _logger = _options.Logger ?? new ConsoleLogger();
+
+        var httpClient = _offline ? new OfflineHttpClient() : _options.HttpClient;
+        API = new SchematicApi(apiKey, _options.WithHttpClient(httpClient));
+
+        _eventBuffer = new EventBuffer(
+            API.Events,
+            _logger,
+            _options.EventBufferPeriod
+        );
+
+        _flagCheckCacheProviders = _options.CacheProviders ?? new List<ICacheProvider<bool>>
+        {
+            new LocalCache<bool>()
+        };
+    }
+
+    public void Shutdown()
+    {
+        _eventBuffer.Stop();
+    }
+
+    public async Task<bool> CheckFlag(string flagKey, Dictionary<string, string>? company = null, Dictionary<string, string>? user = null)
+    {
+        if (_offline)
+            return GetFlagDefault(flagKey);
+
+        try
+        {
+            string cacheKey = (company != null || user != null)
+                ? $"{flagKey}:{company}:{user}"
+                : flagKey;
+
+            foreach (var provider in _flagCheckCacheProviders)
+            {
+                if (provider.Get(cacheKey) is bool cachedValue)
+                    return cachedValue;
+            }
+
+            var requestBody = new CheckFlagRequestBody
+            {
+                Company = company,
+                User = user
+            };
+
+            var response = await API.Features.CheckFlagAsync(flagKey, requestBody);
+            if (response == null)
+                return GetFlagDefault(flagKey);
+
+            foreach (var provider in _flagCheckCacheProviders)
+            {
+                provider.Set(cacheKey, response.Data.Value);
+            }
+
+            return response.Data.Value;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error("Error checking flag: {0}", ex.Message);
+
+            return GetFlagDefault(flagKey);
+        }
+    }
+
+    public void Identify(Dictionary<string, string> keys, EventBodyIdentifyCompany? company = null, string? name = null, Dictionary<string, OneOf<string, double, bool, OneOf<string, double, bool>>>? traits = null)
+    {
+        EnqueueEvent(CreateEventRequestBodyEventType.Identify, new EventBodyIdentify
+        {
+            Company = company,
+            Keys = keys,
+            Name = name,
+            Traits = traits
+        });
+    }
+
+    public void Track(string eventName, Dictionary<string, string>? company = null, Dictionary<string, string>? user = null, Dictionary<string, OneOf<string, double, bool, OneOf<string, double, bool>>>? traits = null)
+    {
+        EnqueueEvent(CreateEventRequestBodyEventType.Track, new EventBodyTrack
+        {
+            Company = company,
+            Event = eventName,
+            Traits = traits,
+            User = user
+        });
+    }
+
+    private void EnqueueEvent(CreateEventRequestBodyEventType eventType, OneOf<EventBodyTrack, EventBodyIdentify> body)
+    {
+        if (_offline)
+            return;
+
+        try
+        {
+            var eventBody = new CreateEventRequestBody
+            {
+                EventType = eventType,
+                Body = body
+            };
+
+            _eventBuffer.Push(eventBody);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error("Error enqueueing event: {0}", ex.Message);
+        }
+    }
+
+    private bool GetFlagDefault(string flagKey)
+    {
+        return _options.FlagDefaults?.GetValueOrDefault(flagKey) ?? false;
+    }
+}
+
+public class OfflineHttpClient : HttpClient
+{
+    public override HttpResponseMessage Send(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
+    {
+        var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":{}}")
+        };
+        return response;
+    }
+}


### PR DESCRIPTION
This pull request implements Schematic V1 functionality for Schematic's C# library; V1 adds the following custom functionality:
* Configurable in-memory caching for flag check evaluations (users should get an in-memory cache for flag check results by default, which they can disable, configure its TTL or max size, or even bring their own cache implementation)
* Event buffering (i.e., track and identify events can be submitted via a non-blocking top-level function, and will be sent in batches behind the scenes)
* Offline mode (to support local development environments without a Schematic API key, CI testing environments, etc)