### PR TITLE
OpenFeature

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -13,6 +13,7 @@ src/SchematicHQ.Client.Test/TestCompaniesClient.cs
 src/SchematicHQ.Client.Test/TestEventBuffer.cs
 src/SchematicHQ.Client.Test/TestLogger.cs
 src/SchematicHQ.Client.Test/Webhooks/
+src/SchematicHQ.Client.Test/OpenFeature/
 src/SchematicHQ.Client/Cache/
 src/SchematicHQ.Client/Core/Public/ClientOptionsCustom.cs
 src/SchematicHQ.Client/Datastream

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ This is the official Schematic .NET client library for C#, supporting .NET Stand
 
 Much of this repository is generated using [Fern](https//buildwithfern.com). All files that are not listed in the .fernignore file will be regenerated over. If you need to edit any files in this repo, please ensure they are in .fernignore, or add them; if you're editing a generated file, you likely want to create a new file instead and add it to .fernignore, so as to keep generated and non-generated code separate.
 
+If you need to extend the SchematicHQ.Client.csproj file in src/SchematicHQ.Client/, you can do this in teh custom props file: src/SchematicHQ.Client/SchematicHQ.Client.Custom.props. This will prevent your changes from being overwritten when the Fern code generation runs.
+
 ## Repository Structure
 
 - `src/` - Contains the source code for the library

--- a/README.md
+++ b/README.md
@@ -189,6 +189,69 @@ bool flagValue = await schematic.CheckFlag(
 );
 ```
 
+### OpenFeature Integration
+
+The Schematic .NET SDK includes built-in support for [OpenFeature](https://openfeature.dev/), allowing you to use Schematic's feature flags through the OpenFeature standard API.
+
+#### Using Schematic with OpenFeature
+
+```csharp
+using OpenFeature;
+using SchematicHQ.Client.OpenFeature;
+
+// Create and set the Schematic provider
+var provider = new SchematicProvider("YOUR_API_KEY");
+await Api.Instance.SetProviderAsync(provider);
+
+// Get the OpenFeature client
+var client = Api.Instance.GetClient();
+
+// Evaluate a boolean feature flag
+var isEnabled = await client.GetBooleanValue("your-flag-key", false);
+```
+
+#### OpenFeature Context
+
+The Schematic provider supports company and user context through OpenFeature's evaluation context:
+
+```csharp
+var context = EvaluationContext.Builder()
+    .Set("company", new Structure(new Dictionary<string, Value>
+    {
+        ["id"] = new Value("company-123"),
+        ["name"] = new Value("Acme Corp"),
+        ["plan"] = new Value("enterprise")
+    }))
+    .Set("user", new Structure(new Dictionary<string, Value>
+    {
+        ["id"] = new Value("user-456"),
+        ["email"] = new Value("user@example.com"),
+        ["role"] = new Value("admin")
+    }))
+    .Build();
+
+// Evaluate with context
+var isEnabled = await client.GetBooleanValue("your-flag-key", false, context);
+```
+
+#### Event Tracking with OpenFeature
+
+The provider includes a method to track events:
+
+```csharp
+var provider = (SchematicProvider)Api.Instance.GetProvider();
+
+await provider.TrackEventAsync(
+    "button_clicked",
+    context,
+    new Dictionary<string, object>
+    {
+        ["button_name"] = "submit",
+        ["page"] = "checkout"
+    }
+);
+```
+
 ## Webhook Verification
 
 Schematic can send webhooks to notify your application of events. To ensure the security of these webhooks, Schematic signs each request using HMAC-SHA256. The .NET SDK provides utility functions to verify these signatures.

--- a/examples/OpenFeature/OpenFeatureExample.cs
+++ b/examples/OpenFeature/OpenFeatureExample.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OpenFeature;
+using OpenFeature.Model;
+using SchematicHQ.Client;
+using SchematicHQ.Client.OpenFeature;
+
+namespace Examples.OpenFeature
+{
+    public class OpenFeatureExample
+    {
+        public static async Task Main(string[] args)
+        {
+            // Initialize the Schematic OpenFeature provider
+            var apiKey = Environment.GetEnvironmentVariable("SCHEMATIC_API_KEY") ?? "your-api-key";
+            var provider = new SchematicProvider(apiKey);
+            
+            // Set the provider with OpenFeature
+            await Api.Instance.SetProviderAsync(provider);
+            
+            // Create evaluation context
+            var context = EvaluationContext.Builder()
+                .Set("company", new Structure(new Dictionary<string, Value>
+                {
+                    ["id"] = new Value("company-123"),
+                    ["name"] = new Value("Acme Corp"),
+                    ["plan"] = new Value("enterprise")
+                }))
+                .Set("user", new Structure(new Dictionary<string, Value>
+                {
+                    ["id"] = new Value("user-456"),
+                    ["email"] = new Value("user@example.com"),
+                    ["role"] = new Value("admin")
+                }))
+                .Build();
+            
+            // Get the OpenFeature client
+            var client = Api.Instance.GetClient();
+            
+            // Evaluate a feature flag
+            var isFeatureEnabled = await client.GetBooleanValue("new-feature", false, context);
+            Console.WriteLine($"Feature 'new-feature' is {(isFeatureEnabled ? "enabled" : "disabled")}");
+            
+            // Get detailed flag evaluation
+            var flagDetails = await client.GetBooleanDetails("new-feature", false, context);
+            Console.WriteLine($"Flag evaluation reason: {flagDetails.Reason}");
+            
+            // Track an event using the provider
+            await provider.TrackEventAsync("feature_viewed", context, new Dictionary<string, object>
+            {
+                ["feature"] = "new-feature",
+                ["enabled"] = isFeatureEnabled
+            });
+            
+            // Shutdown
+            await Api.Instance.Shutdown();
+        }
+    }
+}

--- a/src/SchematicHQ.Client.Test/OpenFeature/SchematicProviderOfflineTests.cs
+++ b/src/SchematicHQ.Client.Test/OpenFeature/SchematicProviderOfflineTests.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using OpenFeature;
+using OpenFeature.Constant;
+using OpenFeature.Model;
+using SchematicHQ.Client;
+using SchematicHQ.Client.OpenFeature;
+
+namespace SchematicHQ.Client.Test.OpenFeature
+{
+    [TestFixture]
+    public class SchematicProviderOfflineTests
+    {
+        [Test]
+        public void GetMetadata_ReturnsCorrectName()
+        {
+            var provider = new SchematicProvider("test-key");
+            var metadata = provider.GetMetadata();
+            Assert.That(metadata.Name, Is.EqualTo("schematic-provider"));
+        }
+
+        [Test]
+        public async Task ResolveBooleanValue_InOfflineMode_ReturnsDefaultValue()
+        {
+            // Arrange
+            var options = new ClientOptions
+            {
+                Offline = true,
+                FlagDefaults = new Dictionary<string, bool>
+                {
+                    ["test-flag"] = true,
+                    ["other-flag"] = false
+                }
+            };
+            var provider = new SchematicProvider("test-key", options);
+            var context = EvaluationContext.Empty;
+
+            // Act
+            var result = await provider.ResolveBooleanValue("test-flag", false, context);
+
+            // Assert
+            Assert.That(result.FlagKey, Is.EqualTo("test-flag"));
+            Assert.That(result.Value, Is.True);
+            Assert.That(result.Variant, Is.EqualTo("on"));
+            Assert.That(result.Reason, Is.EqualTo(Reason.Cached));
+        }
+
+        [Test]
+        public async Task ResolveBooleanValue_FlagNotInDefaults_ReturnsFalse()
+        {
+            // Arrange
+            var options = new ClientOptions
+            {
+                Offline = true,
+                FlagDefaults = new Dictionary<string, bool>
+                {
+                    ["existing-flag"] = true
+                }
+            };
+            var provider = new SchematicProvider("test-key", options);
+
+            // Act
+            // In offline mode, Schematic returns false for flags not in defaults, regardless of the provided default
+            var result = await provider.ResolveBooleanValue("non-existent-flag", true, EvaluationContext.Empty);
+
+            // Assert
+            Assert.That(result.Value, Is.False); // Schematic always returns false for unknown flags in offline mode
+            Assert.That(result.Reason, Is.EqualTo(Reason.Cached));
+        }
+
+        [Test]
+        public async Task ResolveBooleanValue_WithContext_ExtractsCorrectly()
+        {
+            // Arrange
+            var options = new ClientOptions
+            {
+                Offline = true,
+                FlagDefaults = new Dictionary<string, bool>
+                {
+                    ["feature-x"] = true
+                }
+            };
+            var provider = new SchematicProvider("test-key", options);
+            
+            var context = EvaluationContext.Builder()
+                .Set("company", new Structure(new Dictionary<string, Value>
+                {
+                    ["id"] = new Value("company-123"),
+                    ["name"] = new Value("Test Company")
+                }))
+                .Set("user", new Structure(new Dictionary<string, Value>
+                {
+                    ["id"] = new Value("user-456"),
+                    ["email"] = new Value("test@example.com")
+                }))
+                .Build();
+
+            // Act - In offline mode, context is ignored but should not cause errors
+            var result = await provider.ResolveBooleanValue("feature-x", false, context);
+
+            // Assert
+            Assert.That(result.Value, Is.True);
+        }
+
+        [Test]
+        public async Task ResolveBooleanValue_WithTargetingKey_HandlesCorrectly()
+        {
+            // Arrange
+            var options = new ClientOptions
+            {
+                Offline = true,
+                FlagDefaults = new Dictionary<string, bool>
+                {
+                    ["test-flag"] = true
+                }
+            };
+            var provider = new SchematicProvider("test-key", options);
+            
+            var context = EvaluationContext.Builder()
+                .SetTargetingKey("user-123")
+                .Build();
+
+            // Act
+            var result = await provider.ResolveBooleanValue("test-flag", false, context);
+
+            // Assert
+            Assert.That(result.Value, Is.True);
+        }
+
+        [Test]
+        public async Task ResolveStringValue_ReturnsUnsupportedType()
+        {
+            // Arrange
+            var provider = new SchematicProvider("test-key");
+            var context = EvaluationContext.Empty;
+
+            // Act
+            var result = await provider.ResolveStringValue("test-flag", "default", context);
+
+            // Assert
+            Assert.That(result.FlagKey, Is.EqualTo("test-flag"));
+            Assert.That(result.Value, Is.EqualTo("default"));
+            Assert.That(result.Reason, Is.EqualTo(Reason.Error));
+            Assert.That(result.ErrorType, Is.EqualTo(ErrorType.TypeMismatch));
+            Assert.That(result.ErrorMessage, Does.Contain("not supported"));
+        }
+
+        [Test]
+        public async Task ResolveIntegerValue_ReturnsUnsupportedType()
+        {
+            // Arrange
+            var provider = new SchematicProvider("test-key");
+
+            // Act
+            var result = await provider.ResolveIntegerValue("test-flag", 42, EvaluationContext.Empty);
+
+            // Assert
+            Assert.That(result.Value, Is.EqualTo(42));
+            Assert.That(result.Reason, Is.EqualTo(Reason.Error));
+            Assert.That(result.ErrorType, Is.EqualTo(ErrorType.TypeMismatch));
+        }
+
+        [Test]
+        public async Task ResolveDoubleValue_ReturnsUnsupportedType()
+        {
+            // Arrange
+            var provider = new SchematicProvider("test-key");
+
+            // Act
+            var result = await provider.ResolveDoubleValue("test-flag", 3.14, EvaluationContext.Empty);
+
+            // Assert
+            Assert.That(result.Value, Is.EqualTo(3.14));
+            Assert.That(result.Reason, Is.EqualTo(Reason.Error));
+            Assert.That(result.ErrorType, Is.EqualTo(ErrorType.TypeMismatch));
+        }
+
+        [Test]
+        public async Task ResolveStructureValue_ReturnsUnsupportedType()
+        {
+            // Arrange
+            var provider = new SchematicProvider("test-key");
+            var defaultValue = new Value(new Structure(new Dictionary<string, Value>()));
+
+            // Act
+            var result = await provider.ResolveStructureValue("test-flag", defaultValue, EvaluationContext.Empty);
+
+            // Assert
+            Assert.That(result.Value, Is.EqualTo(defaultValue));
+            Assert.That(result.Reason, Is.EqualTo(Reason.Error));
+            Assert.That(result.ErrorType, Is.EqualTo(ErrorType.TypeMismatch));
+        }
+
+        [Test]
+        public async Task Initialize_CompletesSuccessfully()
+        {
+            // Arrange
+            var provider = new SchematicProvider("test-key");
+
+            // Act & Assert (should not throw)
+            await provider.Initialize(EvaluationContext.Empty);
+        }
+
+        [Test]
+        public async Task Shutdown_InOfflineMode_CompletesSuccessfully()
+        {
+            // Arrange
+            var options = new ClientOptions { Offline = true };
+            var provider = new SchematicProvider("test-key", options);
+
+            // Act & Assert (should not throw)
+            await provider.Shutdown();
+        }
+
+        [Test]
+        public async Task TrackEventAsync_WithEmptyEventName_ThrowsArgumentException()
+        {
+            // Arrange
+            var provider = new SchematicProvider("test-key");
+
+            // Act & Assert
+            Assert.ThrowsAsync<ArgumentException>(async () => 
+                await provider.TrackEventAsync("", EvaluationContext.Empty));
+        }
+
+        [Test]
+        public async Task TrackEventAsync_InOfflineMode_CompletesSuccessfully()
+        {
+            // Arrange
+            var options = new ClientOptions { Offline = true };
+            var provider = new SchematicProvider("test-key", options);
+            
+            var context = EvaluationContext.Builder()
+                .Set("company", new Structure(new Dictionary<string, Value>
+                {
+                    ["id"] = new Value("company-123")
+                }))
+                .Build();
+
+            var traits = new Dictionary<string, object>
+            {
+                ["action"] = "clicked"
+            };
+
+            // Act & Assert (should not throw)
+            await provider.TrackEventAsync("button_click", context, traits);
+        }
+
+        [Test]
+        public void Constructor_WithEmptyApiKey_ThrowsArgumentException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => new SchematicProvider(""));
+        }
+
+        [Test]
+        public void Constructor_WithNullSchematic_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new SchematicProvider((Schematic)null!));
+        }
+    }
+}

--- a/src/SchematicHQ.Client.Test/SchematicHQ.Client.Test.csproj
+++ b/src/SchematicHQ.Client.Test/SchematicHQ.Client.Test.csproj
@@ -25,6 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="WireMock.Net" Version="1.7.4" />
+    <PackageReference Include="OpenFeature" Version="1.5.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SchematicHQ.Client\SchematicHQ.Client.csproj" />

--- a/src/SchematicHQ.Client/OpenFeature/SchematicProvider.cs
+++ b/src/SchematicHQ.Client/OpenFeature/SchematicProvider.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenFeature;
+using OpenFeature.Constant;
+using OpenFeature.Error;
+using OpenFeature.Model;
+
+namespace SchematicHQ.Client.OpenFeature
+{
+    /// <summary>
+    /// OpenFeature provider for Schematic feature flags.
+    /// </summary>
+    public class SchematicProvider : FeatureProvider
+    {
+        private static readonly Metadata _metadata = new Metadata("schematic-provider");
+        private readonly Schematic _schematic;
+        private readonly ClientOptions _options;
+
+        /// <summary>
+        /// Creates a new instance of the SchematicProvider.
+        /// </summary>
+        /// <param name="apiKey">The Schematic API key.</param>
+        /// <param name="options">Optional client configuration options.</param>
+        public SchematicProvider(string apiKey, ClientOptions? options = null)
+        {
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                throw new ArgumentException("API key is required", nameof(apiKey));
+            }
+
+            _options = options ?? new ClientOptions();
+            _schematic = new Schematic(apiKey, _options);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the SchematicProvider with a pre-configured Schematic client.
+        /// </summary>
+        /// <param name="schematic">A pre-configured Schematic client instance.</param>
+        /// <param name="options">Optional client configuration options.</param>
+        public SchematicProvider(Schematic schematic, ClientOptions? options = null)
+        {
+            _schematic = schematic ?? throw new ArgumentNullException(nameof(schematic));
+            _options = options ?? new ClientOptions();
+        }
+
+        /// <inheritdoc/>
+        public override Metadata GetMetadata()
+        {
+            return _metadata;
+        }
+
+        /// <inheritdoc/>
+        public override async Task<ResolutionDetails<bool>> ResolveBooleanValue(
+            string flagKey, 
+            bool defaultValue, 
+            EvaluationContext context = null)
+        {
+            try
+            {
+                var (company, user) = ExtractContext(context);
+                
+                var result = await _schematic.CheckFlag(
+                    flagKey: flagKey,
+                    company: company,
+                    user: user
+                ).ConfigureAwait(false);
+
+                return new ResolutionDetails<bool>(
+                    flagKey: flagKey,
+                    value: result,
+                    variant: result ? "on" : "off",
+                    reason: Reason.Cached
+                );
+            }
+            catch (Exception ex)
+            {
+                _options.Logger?.Error("Error evaluating boolean flag '{0}': {1}", flagKey, ex.Message);
+                
+                var errorType = MapExceptionToErrorType(ex);
+                return new ResolutionDetails<bool>(
+                    flagKey: flagKey,
+                    value: defaultValue,
+                    variant: defaultValue ? "on" : "off",
+                    reason: Reason.Error,
+                    errorType: errorType,
+                    errorMessage: ex.Message
+                );
+            }
+        }
+
+        /// <inheritdoc/>
+        public override Task<ResolutionDetails<string>> ResolveStringValue(
+            string flagKey, 
+            string defaultValue, 
+            EvaluationContext context = null)
+        {
+            return Task.FromResult(new ResolutionDetails<string>(
+                flagKey: flagKey,
+                value: defaultValue,
+                reason: Reason.Error,
+                errorType: ErrorType.TypeMismatch,
+                errorMessage: "String flags are not supported by Schematic provider"
+            ));
+        }
+
+        /// <inheritdoc/>
+        public override Task<ResolutionDetails<int>> ResolveIntegerValue(
+            string flagKey, 
+            int defaultValue, 
+            EvaluationContext context = null)
+        {
+            return Task.FromResult(new ResolutionDetails<int>(
+                flagKey: flagKey,
+                value: defaultValue,
+                reason: Reason.Error,
+                errorType: ErrorType.TypeMismatch,
+                errorMessage: "Integer flags are not supported by Schematic provider"
+            ));
+        }
+
+        /// <inheritdoc/>
+        public override Task<ResolutionDetails<double>> ResolveDoubleValue(
+            string flagKey, 
+            double defaultValue, 
+            EvaluationContext context = null)
+        {
+            return Task.FromResult(new ResolutionDetails<double>(
+                flagKey: flagKey,
+                value: defaultValue,
+                reason: Reason.Error,
+                errorType: ErrorType.TypeMismatch,
+                errorMessage: "Double flags are not supported by Schematic provider"
+            ));
+        }
+
+        /// <inheritdoc/>
+        public override Task<ResolutionDetails<Value>> ResolveStructureValue(
+            string flagKey, 
+            Value defaultValue, 
+            EvaluationContext context = null)
+        {
+            return Task.FromResult(new ResolutionDetails<Value>(
+                flagKey: flagKey,
+                value: defaultValue,
+                reason: Reason.Error,
+                errorType: ErrorType.TypeMismatch,
+                errorMessage: "Structure flags are not supported by Schematic provider"
+            ));
+        }
+
+        /// <inheritdoc/>
+        public override Task Initialize(EvaluationContext context)
+        {
+            _options.Logger?.Info("Schematic provider initialized");
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public override async Task Shutdown()
+        {
+            _options.Logger?.Info("Schematic provider shutting down");
+            await _schematic.Shutdown().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Tracks an event in Schematic.
+        /// </summary>
+        /// <param name="eventName">The name of the event to track.</param>
+        /// <param name="context">The evaluation context containing user and company information.</param>
+        /// <param name="traits">Additional event properties.</param>
+        public Task TrackEventAsync(
+            string eventName, 
+            EvaluationContext context = null, 
+            Dictionary<string, object>? traits = null)
+        {
+            if (string.IsNullOrWhiteSpace(eventName))
+            {
+                throw new ArgumentException("Event name is required", nameof(eventName));
+            }
+
+            var (company, user) = ExtractContext(context);
+            var eventTraits = traits ?? new Dictionary<string, object>();
+
+            // Add context attributes to traits if they don't conflict
+            if (context != null)
+            {
+                foreach (var attr in context.AsDictionary())
+                {
+                    if (attr.Key != "company" && attr.Key != "user" && !eventTraits.ContainsKey(attr.Key))
+                    {
+                        eventTraits[attr.Key] = attr.Value.AsObject ?? attr.Value.ToString();
+                    }
+                }
+            }
+
+            _schematic.Track(
+                eventName: eventName,
+                company: company,
+                user: user,
+                traits: eventTraits
+            );
+
+            return Task.CompletedTask;
+        }
+
+        private static (Dictionary<string, string>? company, Dictionary<string, string>? user) ExtractContext(EvaluationContext context)
+        {
+            if (context == null)
+            {
+                return (null, null);
+            }
+
+            Dictionary<string, string>? company = null;
+            Dictionary<string, string>? user = null;
+
+            // Extract company context
+            if (context.TryGetValue("company", out var companyValue) && companyValue.IsStructure)
+            {
+                company = companyValue.AsStructure
+                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.AsString ?? kvp.Value.ToString());
+            }
+
+            // Extract user context
+            if (context.TryGetValue("user", out var userValue) && userValue.IsStructure)
+            {
+                user = userValue.AsStructure
+                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.AsString ?? kvp.Value.ToString());
+            }
+
+            // If there's a targeting key but no user ID, set it as the user ID
+            if (!string.IsNullOrEmpty(context.TargetingKey) && user?.ContainsKey("id") != true)
+            {
+                user ??= new Dictionary<string, string>();
+                user["id"] = context.TargetingKey;
+            }
+
+            return (company, user);
+        }
+
+        private static ErrorType MapExceptionToErrorType(Exception ex)
+        {
+            return ex switch
+            {
+                ArgumentException => ErrorType.InvalidContext,
+                UnauthorizedAccessException => ErrorType.General,
+                NotImplementedException => ErrorType.FlagNotFound,
+                _ => ErrorType.General
+            };
+        }
+    }
+}

--- a/src/SchematicHQ.Client/OpenFeature/ValueExtensions.cs
+++ b/src/SchematicHQ.Client/OpenFeature/ValueExtensions.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using OpenFeature.Model;
+
+namespace SchematicHQ.Client.OpenFeature
+{
+    /// <summary>
+    /// Extension methods for OpenFeature Value types.
+    /// </summary>
+    internal static class ValueExtensions
+    {
+        /// <summary>
+        /// Converts an OpenFeature Value to a dictionary of strings.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>A dictionary of string key-value pairs, or null if the value is not a structure.</returns>
+        public static Dictionary<string, string>? ToDictionaryString(this Value value)
+        {
+            if (!value.IsStructure)
+            {
+                return null;
+            }
+
+            return value.AsStructure
+                .Where(kvp => kvp.Value.IsString || kvp.Value.IsNumber || kvp.Value.IsBoolean)
+                .ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => kvp.Value.AsString ?? kvp.Value.ToString()
+                );
+        }
+
+        /// <summary>
+        /// Converts an OpenFeature Value to a dictionary of objects.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>A dictionary of object values, or null if the value is not a structure.</returns>
+        public static Dictionary<string, object>? ToDictionaryObject(this Value value)
+        {
+            if (!value.IsStructure)
+            {
+                return null;
+            }
+
+            return value.AsStructure
+                .ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => ConvertValueToObject(kvp.Value)
+                );
+        }
+
+        private static object ConvertValueToObject(Value value)
+        {
+            if (value.IsNull)
+                return null!;
+            if (value.IsBoolean)
+                return value.AsBoolean!.Value;
+            if (value.IsNumber)
+                return value.AsDouble!.Value;
+            if (value.IsString)
+                return value.AsString!;
+            if (value.IsList)
+                return value.AsList!.Select(ConvertValueToObject).ToList();
+            if (value.IsStructure)
+                return value.ToDictionaryObject()!;
+            if (value.IsDateTime)
+                return value.AsDateTime!.Value;
+            
+            return value.AsObject!;
+        }
+    }
+}

--- a/src/SchematicHQ.Client/SchematicHQ.Client.Custom.props
+++ b/src/SchematicHQ.Client/SchematicHQ.Client.Custom.props
@@ -8,6 +8,7 @@ Configure additional MSBuild properties for your project in this file:
     <TargetFrameworks>net8.0;</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="OpenFeature" Version="1.5.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds native support for the [OpenFeature](https://openfeature.dev/) specification to the Schematic .NET SDK, allowing users to integrate Schematic's feature flags through the vendor-agnostic OpenFeature API.

We had previously attempted to ship a version of this in OpenFeature's own C# contrib library, but were unable to get this merged. By shipping this within our own library, we can allow our C# users to install the same package from NuGet regardless of whether they are using OpenFeature or using Schematic directly. And this avoids adding the overhead of shipping multiple C# packages to NuGet, or of working through OpenFeature's review processes for their contrib package and repo. Simplifies versioning as well (eg, no need to ship new versions of an OpenFeature package if the underlying client changed)