### PR TITLE
Update buffer to be channel-based and eliminate locking

### DIFF
--- a/src/SchematicHQ.Client.Test/TestEventBuffer.cs
+++ b/src/SchematicHQ.Client.Test/TestEventBuffer.cs
@@ -46,11 +46,9 @@ namespace SchematicHQ.Client.Tests
             await _buffer.Stop();
 
             Assert.Throws<InvalidOperationException>(() => _buffer.Push(1));
-
-            var semaphore = GetPrivateFieldValue<SemaphoreSlim>(_buffer, "_semaphore");
+            
             var cts = GetPrivateFieldValue<CancellationTokenSource>(_buffer, "_cts");
-
-            Assert.That(IsSemaphoreSlimDisposed(semaphore), Is.True, "SemaphoreSlim was not disposed.");
+            
             Assert.That(IsCancellationTokenSourceDisposed(cts), Is.True, "CancellationTokenSource was not disposed.");
         }
 

--- a/src/SchematicHQ.Client/EventBuffer.cs
+++ b/src/SchematicHQ.Client/EventBuffer.cs
@@ -1,10 +1,10 @@
-using System.Collections.Concurrent;
+using System.Threading.Channels;
 
 #nullable enable
 
 namespace SchematicHQ.Client;
 
-public interface IEventBuffer<T>
+public interface IEventBuffer<in T> where T: notnull
 {
     void Push(T item);
     void Start();
@@ -13,7 +13,7 @@ public interface IEventBuffer<T>
     int GetEventCount();
 }
 
-public class EventBuffer<T> : IEventBuffer<T>
+public class EventBuffer<T> : IEventBuffer<T> where T : notnull
 {
     private const int DefaultMaxSize = 100;
     private static readonly TimeSpan DefaultFlushPeriod = TimeSpan.FromMilliseconds(5000);
@@ -21,18 +21,18 @@ public class EventBuffer<T> : IEventBuffer<T>
     private const int MaxRetries = 3; // Maximum number of retry attempts
     private const double InitialRetryDelaySeconds = 1.0; // Initial retry delay in seconds
 
+    private const int StateStopped = 0;
+    private const int StateRunning = 1;
+
     private readonly int _maxSize;
     private readonly TimeSpan _flushPeriod;
     private readonly Func<List<T>, Task> _action;
     private readonly ISchematicLogger _logger;
-    private readonly ConcurrentQueue<T> _queue;
-    private readonly SemaphoreSlim _semaphore;
+    private readonly Channel<T> _channel;
     private CancellationTokenSource _cts;
-    private bool _isRunning;
+    private int _state;
     private Task _periodicFlushTask = Task.CompletedTask;
     private Task _processBufferTask = Task.CompletedTask;
-    private readonly object _taskLock = new object();
-    private readonly object _runningLock = new object();
 
     public EventBuffer(Func<List<T>, Task> action, ISchematicLogger logger, int maxSize = DefaultMaxSize, TimeSpan? flushPeriod = null)
     {
@@ -40,10 +40,13 @@ public class EventBuffer<T> : IEventBuffer<T>
         _flushPeriod = flushPeriod ?? DefaultFlushPeriod;
         _action = action ?? throw new ArgumentNullException(nameof(action));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _queue = new ConcurrentQueue<T>();
-        _semaphore = new SemaphoreSlim(0);
+        _channel = Channel.CreateUnbounded<T>(new UnboundedChannelOptions
+        {
+            SingleReader = false,
+            SingleWriter = false
+        });
         _cts = new CancellationTokenSource();
-        _isRunning = false;
+        _state = StateStopped;
 
         _logger.Debug("EventBuffer initialized with maxSize: {0}, flushPeriod: {1}", _maxSize, _flushPeriod);
 
@@ -62,9 +65,8 @@ public class EventBuffer<T> : IEventBuffer<T>
         try
         {
             _logger.Debug("Emergency flush triggered by program termination");
-            // Don't check _isRunning here since we're in an emergency shutdown
-            var items = new List<T>();
-            while (_queue.TryDequeue(out var item))
+            var items = new List<T>(_channel.Reader.Count);
+            while (_channel.Reader.TryRead(out var item))
             {
                 items.Add(item);
             }
@@ -84,56 +86,42 @@ public class EventBuffer<T> : IEventBuffer<T>
 
     public void Push(T item)
     {
-        lock (_runningLock)
-        {
-            if (!_isRunning) throw new InvalidOperationException("Buffer is not running.");
-        }
+        if (Volatile.Read(ref _state) != StateRunning)
+            throw new InvalidOperationException("Buffer is not running.");
 
-        _queue.Enqueue(item);
-        _logger.Debug("Item added to buffer. Current size: {0}", _queue.Count);
-        if (_queue.Count >= _maxSize)
-        {
-            _semaphore.Release();
-        }
+        if (!_channel.Writer.TryWrite(item))
+            throw new InvalidOperationException("Failed to write item to buffer channel.");
+
+        _logger.Debug("Item added to buffer. Current size: {0}", _channel.Reader.Count);
     }
 
     public void Start()
     {
-        lock (_runningLock)
-        {
-            if (_isRunning) return;
+        if (Interlocked.CompareExchange(ref _state, StateRunning, StateStopped) != StateStopped)
+            return;
 
-            _isRunning = true;
-            _cts = new CancellationTokenSource();
-        }
-
-        lock (_taskLock)
-        {
-            if (_periodicFlushTask == Task.CompletedTask || _periodicFlushTask.IsCompleted)
-            {
-                _periodicFlushTask = Task.Run(() => PeriodicFlushAsync(_cts.Token));
-            }
-            if (_processBufferTask == Task.CompletedTask || _processBufferTask.IsCompleted)
-            {
-                _processBufferTask = Task.Run(() => ProcessBufferAsync(_cts.Token));
-            }
-        }
+        _cts = new CancellationTokenSource();
+        _periodicFlushTask = Task.Run(() => PeriodicFlushAsync(_cts.Token));
+        _processBufferTask = Task.Run(() => ProcessBufferAsync(_cts.Token));
 
         _logger.Info("EventBuffer started.");
     }
 
     public async Task Flush()
     {
-        lock (_runningLock)
-        {
-            if (!_isRunning) throw new InvalidOperationException("Buffer is not running.");
-        }
+        if (Volatile.Read(ref _state) != StateRunning)
+            throw new InvalidOperationException("Buffer is not running.");
 
-        while (!_queue.IsEmpty)
+        await DrainAsync();
+        _logger.Info("Buffer flushed manually.");
+    }
+
+    private async Task DrainAsync()
+    {
+        while (_channel.Reader.Count > 0)
         {
             await FlushBufferAsync();
         }
-        _logger.Info("Buffer flushed manually.");
     }
 
     private async Task ProcessBufferAsync(CancellationToken token)
@@ -142,12 +130,23 @@ public class EventBuffer<T> : IEventBuffer<T>
         {
             try
             {
-                await _semaphore.WaitAsync(token);
-                await FlushBufferAsync();
+                // Wait for at least one item to be available
+                await _channel.Reader.WaitToReadAsync(token);
+
+                // Check if we've accumulated enough items for a batch flush
+                if (_channel.Reader.Count >= _maxSize)
+                {
+                    await FlushBufferAsync();
+                }
             }
             catch (OperationCanceledException)
             {
                 _logger.Warn("Process buffer task was canceled.");
+            }
+            catch (ChannelClosedException)
+            {
+                _logger.Debug("Channel closed, process buffer task exiting.");
+                break;
             }
         }
     }
@@ -160,7 +159,7 @@ public class EventBuffer<T> : IEventBuffer<T>
             {
                 await Task.Delay(_flushPeriod, token);
 
-                if (_queue.Count > 0)
+                if (_channel.Reader.Count > 0)
                 {
                     await FlushBufferAsync();
                 }
@@ -178,8 +177,8 @@ public class EventBuffer<T> : IEventBuffer<T>
 
     private async Task FlushBufferAsync()
     {
-        var items = new List<T>();
-        while (items.Count < _maxSize && _queue.TryDequeue(out var item))
+        var items = new List<T>(_channel.Reader.Count);
+        while (items.Count < _maxSize && _channel.Reader.TryRead(out var item))
         {
             items.Add(item);
         }
@@ -192,7 +191,6 @@ public class EventBuffer<T> : IEventBuffer<T>
             int retryCount = 0;
             bool success = false;
             Exception? lastException = null;
-            Random random = new Random();
 
             // Try with retries and exponential backoff
             while (retryCount <= MaxRetries && !success)
@@ -219,7 +217,7 @@ public class EventBuffer<T> : IEventBuffer<T>
                         // Calculate backoff with jitter
                         double baseDelay = InitialRetryDelaySeconds;
                         double delay = baseDelay * Math.Pow(2, retryCount - 1);
-                        double jitter = random.NextDouble() * 0.1 * delay; // 10% jitter
+                        double jitter = Random.Shared.NextDouble() * 0.1 * delay; // 10% jitter
                         TimeSpan waitTime = TimeSpan.FromSeconds(delay + jitter);
 
                         _logger.Warn(
@@ -247,49 +245,26 @@ public class EventBuffer<T> : IEventBuffer<T>
 
     public async Task Stop()
     {
-        bool needsFlush = false;
-        
-        lock (_runningLock)
-        {
-            if (!_isRunning) return;
-            needsFlush = true;
-        }
+        if (Interlocked.CompareExchange(ref _state, StateStopped, StateRunning) != StateRunning)
+            return;
 
         try
         {
-            if (needsFlush)
+            try
             {
-                try
-                {
-                    await Flush();
-                }
-                catch (InvalidOperationException)
-                {
-                    // Another thread might have changed the state between our check and the flush
-                    // Just continue with shutdown
-                }
+                await DrainAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn("Error draining buffer on stop: {0}", ex.Message);
             }
 
-            lock (_runningLock)
-            {
-                if (!_isRunning) return;
-                _isRunning = false;
-                _cts.Cancel();
-            }
+            await _cts.CancelAsync();
+            _channel.Writer.TryComplete();
 
-            if (_periodicFlushTask != Task.CompletedTask)
-            {
-                var timeoutTask = Task.Delay(TimeSpan.FromSeconds(MaxWaitForBuffer));
-                await Task.WhenAny(_periodicFlushTask, timeoutTask);
-            }
+            var timeout = TimeSpan.FromSeconds(MaxWaitForBuffer);
+            await Task.WhenAny(Task.WhenAll(_periodicFlushTask, _processBufferTask), Task.Delay(timeout));
 
-            if (_processBufferTask != Task.CompletedTask)
-            {
-                var timeoutTask = Task.Delay(TimeSpan.FromSeconds(MaxWaitForBuffer));
-                await Task.WhenAny(_processBufferTask, timeoutTask);
-            }
-
-            _semaphore.Dispose();
             _cts.Dispose();
             _logger.Info("EventBuffer shut down cleanly.");
         }
@@ -302,6 +277,6 @@ public class EventBuffer<T> : IEventBuffer<T>
 
     public int GetEventCount()
     {
-        return _queue.Count;
+        return _channel.Reader.Count;
     }
 }

--- a/src/SchematicHQ.Client/EventBuffer.cs
+++ b/src/SchematicHQ.Client/EventBuffer.cs
@@ -247,6 +247,9 @@ public class EventBuffer<T> : IEventBuffer<T> where T : notnull
 
         try
         {
+            await _cts.CancelAsync();                                                                                                                                                                                                  
+            _channel.Writer.TryComplete();      
+            
             try
             {
                 await DrainAsync();
@@ -256,13 +259,11 @@ public class EventBuffer<T> : IEventBuffer<T> where T : notnull
                 _logger.Warn("Error draining buffer on stop: {0}", ex.Message);
             }
 
-            await _cts.CancelAsync();
-            _channel.Writer.TryComplete();
-
             var timeout = TimeSpan.FromSeconds(MaxWaitForBuffer);
             await Task.WhenAny(Task.WhenAll(_periodicFlushTask, _processBufferTask), Task.Delay(timeout));
 
             _cts.Dispose();
+            _semaphore.Dispose();
             _logger.Info("EventBuffer shut down cleanly.");
         }
         catch (Exception ex)

--- a/src/SchematicHQ.Client/EventBuffer.cs
+++ b/src/SchematicHQ.Client/EventBuffer.cs
@@ -29,6 +29,7 @@ public class EventBuffer<T> : IEventBuffer<T> where T : notnull
     private readonly Func<List<T>, Task> _action;
     private readonly ISchematicLogger _logger;
     private readonly Channel<T> _channel;
+    private readonly SemaphoreSlim _semaphore;
     private CancellationTokenSource _cts;
     private int _state;
     private Task _periodicFlushTask = Task.CompletedTask;
@@ -47,6 +48,7 @@ public class EventBuffer<T> : IEventBuffer<T> where T : notnull
         });
         _cts = new CancellationTokenSource();
         _state = StateStopped;
+        _semaphore = new SemaphoreSlim(0);
 
         _logger.Debug("EventBuffer initialized with maxSize: {0}, flushPeriod: {1}", _maxSize, _flushPeriod);
 
@@ -93,6 +95,11 @@ public class EventBuffer<T> : IEventBuffer<T> where T : notnull
             throw new InvalidOperationException("Failed to write item to buffer channel.");
 
         _logger.Debug("Item added to buffer. Current size: {0}", _channel.Reader.Count);
+        
+        if (_channel.Reader.Count >= _maxSize)
+        {
+            _semaphore.Release();
+        }
     }
 
     public void Start()
@@ -130,23 +137,13 @@ public class EventBuffer<T> : IEventBuffer<T> where T : notnull
         {
             try
             {
-                // Wait for at least one item to be available
-                await _channel.Reader.WaitToReadAsync(token);
-
-                // Check if we've accumulated enough items for a batch flush
-                if (_channel.Reader.Count >= _maxSize)
-                {
-                    await FlushBufferAsync();
-                }
+                await _semaphore.WaitAsync(token);
+                
+                await FlushBufferAsync();
             }
             catch (OperationCanceledException)
             {
                 _logger.Warn("Process buffer task was canceled.");
-            }
-            catch (ChannelClosedException)
-            {
-                _logger.Debug("Channel closed, process buffer task exiting.");
-                break;
             }
         }
     }


### PR DESCRIPTION
The `ConcurrentQueue` + `SemaphoreSlim` combination has been made mostly obsolete by Channels. Also replaced the locks with  read/write barriers as it was unnecessary overhead for this usage.