### PR TITLE
Support IAsyncDisposable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ nuget install SchematicHQ.Client
 using SchematicHQ;
 
 Schematic schematic = new Schematic("YOUR_API_KEY")
+
+// on application exit
+await schematic.DisposeAsync();
 ```
+
+The client implements `IAsyncDisposable` and should be disposed via `await using` or `DisposeAsync()` on application shutdown. This flushes buffered events and closes any datastream connection, equivalent to calling `Shutdown()` directly.
 
 ## Usage
 
@@ -63,9 +68,6 @@ schematic.Identify(
         { "is_staff", false }
     }
 );
-
-// to guarantee that all events are sent before the application exits, call this method before your program shuts down
-await schematic.Shutdown();
 ```
 
 This call is non-blocking and there is no response to check.
@@ -82,8 +84,6 @@ schematic.Track(
     company: new Dictionary<string, string> { { "id", "your-company-id" } }
 );
 
-// to guarantee that all events are sent before the application exits, call this method before your program shuts down
-await schematic.Shutdown();
 ```
 
 This call is non-blocking and there is no response to check.

--- a/src/SchematicHQ.Client.Test/TestClient.cs
+++ b/src/SchematicHQ.Client.Test/TestClient.cs
@@ -131,7 +131,7 @@ namespace SchematicHQ.Client.Test
         [TearDown]
         public async Task TearDown()
         {
-            if (_schematic != null) await _schematic.Shutdown();
+            if (_schematic != null) await _schematic.DisposeAsync();
         }
 
         [Test]
@@ -664,6 +664,22 @@ namespace SchematicHQ.Client.Test
             Assert.That(results.First(r => r.Flag == "flag_a").Value, Is.True);
             Assert.That(results.First(r => r.Flag == "flag_b").Value, Is.False);
         }
+
+        [Test]
+        public async Task DisposeAsync_FlushesBufferedEvents()
+        {
+            // Arrange
+            SetupSchematicTestClient(isOffline: false, response: CreateEventBatchResponse(HttpStatusCode.OK));
+            _schematic.Track("event_name");
+            Assert.That(_schematic.GetBufferWaitingEventCount(), Is.EqualTo(1));
+
+            // Act
+            await _schematic.DisposeAsync();
+
+            // Assert
+            Assert.That(_schematic.GetBufferWaitingEventCount(), Is.EqualTo(0));
+        }
+
 
         [Test]
         public async Task Track_IncludesQuantityWhenProvided()

--- a/src/SchematicHQ.Client.Test/TestCompaniesClient.cs
+++ b/src/SchematicHQ.Client.Test/TestCompaniesClient.cs
@@ -77,7 +77,7 @@ namespace SchematicHQ.Client.Test
         [TearDown]
         public async Task TearDown()
         {
-            if (_schematic != null) await _schematic.Shutdown();
+            if (_schematic != null) await _schematic.DisposeAsync();
         }
 
         [Test]

--- a/src/SchematicHQ.Client/Schematic.cs
+++ b/src/SchematicHQ.Client/Schematic.cs
@@ -14,7 +14,7 @@ using SchematicHQ.Client.RulesEngine;
 
 namespace SchematicHQ.Client;
 
-public partial class Schematic
+public partial class Schematic : IAsyncDisposable
 {
     private readonly ClientOptions _options;
     private readonly IEventBuffer<CreateEventRequestBody> _eventBuffer;
@@ -25,6 +25,8 @@ public partial class Schematic
     private readonly bool _replicatorMode;
     private bool _datastreamConnected;
     private bool _disposed;
+    private readonly object _shutdownLock = new();
+    private Task? _shutdownTask;
     public readonly SchematicApi API;
 
     public AccesstokensClient Accesstokens { get; init; }
@@ -244,10 +246,22 @@ public partial class Schematic
         });
     }
 
-    public async Task Shutdown()
+    /// <summary>
+    /// Flushes buffered events and closes the datastream connection. Idempotent: repeat and concurrent
+    /// callers await the same shutdown work.
+    /// </summary>
+    public Task Shutdown()
+    {
+        lock (_shutdownLock)
+        {
+            return _shutdownTask ??= ShutdownCore();
+        }
+    }
+
+    private async Task ShutdownCore()
     {
         _disposed = true;
-        
+
         if (_eventBuffer != null)
         {
             await _eventBuffer.Stop();
@@ -257,6 +271,16 @@ public partial class Schematic
         {
             _datastreamClient.Close();
         }
+    }
+
+    /// <summary>
+    /// Disposes the client via <see cref="Shutdown"/>, enabling <c>await using</c> and automatic
+    /// disposal by DI containers.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        await Shutdown();
+        GC.SuppressFinalize(this);
     }
 
     public async Task<bool> CheckFlag(string flagKey, Dictionary<string, string>? company = null, Dictionary<string, string>? user = null)


### PR DESCRIPTION
I noticed that calling `Shutdown()` is recommended on application exit, I think this makes sense being called as part of the dispose pattern to be more intuitive 